### PR TITLE
feat(api): implement fetchFollowings API with ArtistInfo VO and update artists DB schema

### DIFF
--- a/backend/src/application/usecase/fetchMyFollowingsUseCase.ts
+++ b/backend/src/application/usecase/fetchMyFollowingsUseCase.ts
@@ -1,8 +1,10 @@
 import { TokenApplicationService } from "../applicationSercices/tokenApplicationService";
+import { UserApiRepository } from "../../domain/interfaces/userApiRepository";
 
 export class FetchMyFollowingsUseCase {
   constructor(
-    private readonly _tokenApplicationService: TokenApplicationService
+    private readonly _tokenApplicationService: TokenApplicationService,
+    private readonly _userApiRepository: UserApiRepository
   ) {}
 
   async run(sessionId: string) {
@@ -11,6 +13,12 @@ export class FetchMyFollowingsUseCase {
       sessionId
     );
 
-    //　TODO: SoundCloudAPIでフォロー中のアーティストを取得
+    //　APIでフォロー中のアーティストを取得
+    const followings = await this._userApiRepository.fetchFollowings(
+      validToken.accessToken
+    );
+
+    // アーティスト情報 を コントローラーに返す
+    return followings;
   }
 }

--- a/backend/src/domain/interfaces/userApiRepository.ts
+++ b/backend/src/domain/interfaces/userApiRepository.ts
@@ -1,5 +1,7 @@
 import { UserInfo } from "../valueObjects/userInfo";
+import { ArtistInfo } from "../valueObjects/artistInfo";
 
 export interface UserApiRepository {
   fetchUser(accessToken: string): Promise<UserInfo>;
+  fetchFollowings(accessToken: string): Promise<Array<ArtistInfo>>;
 }

--- a/backend/src/domain/valueObjects/artistInfo.ts
+++ b/backend/src/domain/valueObjects/artistInfo.ts
@@ -1,0 +1,9 @@
+export class ArtistInfo {
+  constructor(
+    private readonly _externalUserId: number,
+    private readonly _name: string,
+    private readonly _avatarUrl: string,
+    private readonly _publicFavoritesCount: number,
+    private readonly _permalinkUrl: string
+  ) {}
+}

--- a/backend/src/infrastructure/api/userSoundCloudRepository.ts
+++ b/backend/src/infrastructure/api/userSoundCloudRepository.ts
@@ -2,6 +2,7 @@ import { UserApiRepository } from "../../domain/interfaces/userApiRepository";
 import { UserInfo } from "../../domain/valueObjects/userInfo";
 import { config } from "../../config/config";
 import axios from "axios";
+import { ArtistInfo } from "../../domain/valueObjects/artistInfo";
 
 export class UserSoundCloudRepository implements UserApiRepository {
   // ユーザー情報を取得
@@ -9,7 +10,6 @@ export class UserSoundCloudRepository implements UserApiRepository {
     const endPoint = `${config.API_BASE_URL}/me`;
     const headers = {
       accept: "application/json; charset=utf-8",
-      "Content-Type": "application/json; charset=utf-8",
       Authorization: accessToken,
     };
 
@@ -26,6 +26,33 @@ export class UserSoundCloudRepository implements UserApiRepository {
     } catch (error) {
       console.error("fetchUser request failed:", error);
       throw new Error("FetchUser request failed");
+    }
+  }
+
+  // アーティスト情報を取得
+  async fetchFollowings(accessToken: string): Promise<Array<ArtistInfo>> {
+    const endPoint = `${config.API_BASE_URL}/me/followings`;
+    const headers = {
+      accept: "application/json; charset=utf-8",
+      Authorization: accessToken,
+    };
+
+    try {
+      const response = await axios.get(endPoint, { headers: headers });
+
+      return response.data.collection.map(
+        (following: any) =>
+          new ArtistInfo(
+            following.id,
+            following.name,
+            following.avatar_url,
+            following.public_favorites_count,
+            following.permalink_url
+          )
+      );
+    } catch (error) {
+      console.error("fetchFollowings request failed:", error);
+      throw new Error("FetchFollowings request failed");
     }
   }
 }

--- a/backend/src/presentation/controller/userController.ts
+++ b/backend/src/presentation/controller/userController.ts
@@ -1,38 +1,26 @@
 import { Request, Response } from "express";
 import { FetchMyFollowingsUseCase } from "../../application/usecase/fetchMyFollowingsUseCase";
-import { TokenApplicationService } from "../../application/applicationSercices/tokenApplicationService";
-import { SessionRedisRepository } from "../../infrastructure/redis/sessionRedisRepository";
-import { TokenSoundCloudRepository } from "../../infrastructure/api/tokenSoundCloudRepository";
 
-const fetchMyFollowingsUseCase = new FetchMyFollowingsUseCase(
-  new TokenApplicationService(
-    new SessionRedisRepository(),
-    new TokenSoundCloudRepository()
-  )
-);
+export class UserController {
+  constructor(
+    private readonly _fetchMyFollowingsUseCase: FetchMyFollowingsUseCase
+  ) {}
 
-export const userController = async (req: Request, res: Response) => {
-  // リクエスト
-  const sessionId = req.cookies.sessionId;
-  // ユースケース
-  const followings = fetchMyFollowingsUseCase.run(sessionId);
-  // レスポンス
-  res
-    .cookie("sessionId", sessionId, {
-      httpOnly: true,
-      secure: true,
-      sameSite: "none", // TODO：　時間があればCSRF対策　で　csurfを導入する
-    })
-    .status(200)
-    .json({
-      followings: [
-        // {
-        //     name: Travis Sccott,
-        //     avatar_url: https:~,
-        //     public_favorites_count: 123,
-        //     permalink_url: https:~,
-        //   },
-        //   ...
-      ],
-    });
-};
+  async getMyFollowings(req: Request, res: Response): Promise<void> {
+    // リクエスト
+    const sessionId = req.cookies.sessionId;
+    // ユースケース
+    const followings = await this._fetchMyFollowingsUseCase.run(sessionId);
+    // レスポンス
+    res
+      .cookie("sessionId", sessionId, {
+        httpOnly: true,
+        secure: true,
+        sameSite: "none", // TODO：　時間があればCSRF対策　で　csurfを導入する
+      })
+      .status(200)
+      .json({
+        followings: followings,
+      });
+  }
+}

--- a/backend/src/presentation/di/userController.di.ts
+++ b/backend/src/presentation/di/userController.di.ts
@@ -1,0 +1,16 @@
+import { UserController } from "../controller/userController";
+import { FetchMyFollowingsUseCase } from "../../application/usecase/fetchMyFollowingsUseCase";
+import { TokenApplicationService } from "../../application/applicationSercices/tokenApplicationService";
+import { SessionRedisRepository } from "../../infrastructure/redis/sessionRedisRepository";
+import { TokenSoundCloudRepository } from "../../infrastructure/api/tokenSoundCloudRepository";
+import { UserSoundCloudRepository } from "../../infrastructure/api/userSoundCloudRepository";
+
+export const userController = new UserController(
+  new FetchMyFollowingsUseCase(
+    new TokenApplicationService(
+      new SessionRedisRepository(),
+      new TokenSoundCloudRepository()
+    ),
+    new UserSoundCloudRepository()
+  )
+);

--- a/backend/src/presentation/router/userRouter.ts
+++ b/backend/src/presentation/router/userRouter.ts
@@ -1,7 +1,10 @@
 import { Router } from "express";
 import { asyncHandler } from "../../middleware/asyncHandler";
-import { userController } from "../controller/userController";
+import { userController } from "../di/userController.di";
 
 export const userRouter = Router();
 
-userRouter.get("/api/users/following", asyncHandler(userController));
+userRouter.get(
+  "/api/users/following",
+  asyncHandler(userController.getMyFollowings)
+);

--- a/docs/er-diagram.drawio
+++ b/docs/er-diagram.drawio
@@ -1,6 +1,6 @@
 <mxfile host="65bd71144e">
     <diagram id="MVZLGIK-1uPKz9GJWDl0" name="ページ1">
-        <mxGraphModel dx="205" dy="322" grid="1" gridSize="10" guides="1" tooltips="1" connect="1" arrows="1" fold="1" page="1" pageScale="1" pageWidth="827" pageHeight="1169" math="0" shadow="0">
+        <mxGraphModel dx="562" dy="379" grid="1" gridSize="10" guides="1" tooltips="1" connect="1" arrows="1" fold="1" page="1" pageScale="1" pageWidth="827" pageHeight="1169" math="0" shadow="0">
             <root>
                 <mxCell id="0"/>
                 <mxCell id="1" parent="0"/>
@@ -356,7 +356,7 @@
                     </mxGeometry>
                 </mxCell>
                 <mxCell id="110" value="artists" style="shape=table;startSize=30;container=1;collapsible=1;childLayout=tableLayout;fixedRows=1;rowLines=0;fontStyle=1;align=center;resizeLast=1;html=1;" parent="1" vertex="1">
-                    <mxGeometry x="630.5" y="750" width="180" height="240" as="geometry"/>
+                    <mxGeometry x="630.5" y="750" width="180" height="120" as="geometry"/>
                 </mxCell>
                 <mxCell id="111" value="" style="shape=tableRow;horizontal=0;startSize=0;swimlaneHead=0;swimlaneBody=0;fillColor=none;collapsible=0;dropTarget=0;points=[[0,0.5],[1,0.5]];portConstraint=eastwest;top=0;left=0;right=0;bottom=1;" parent="110" vertex="1">
                     <mxGeometry y="30" width="180" height="30" as="geometry"/>
@@ -371,21 +371,8 @@
                         <mxRectangle width="150" height="30" as="alternateBounds"/>
                     </mxGeometry>
                 </mxCell>
-                <mxCell id="114" value="" style="shape=tableRow;horizontal=0;startSize=0;swimlaneHead=0;swimlaneBody=0;fillColor=none;collapsible=0;dropTarget=0;points=[[0,0.5],[1,0.5]];portConstraint=eastwest;top=0;left=0;right=0;bottom=0;" parent="110" vertex="1">
-                    <mxGeometry y="60" width="180" height="30" as="geometry"/>
-                </mxCell>
-                <mxCell id="115" value="" style="shape=partialRectangle;connectable=0;fillColor=none;top=0;left=0;bottom=0;right=0;editable=1;overflow=hidden;whiteSpace=wrap;html=1;" parent="114" vertex="1">
-                    <mxGeometry width="30" height="30" as="geometry">
-                        <mxRectangle width="30" height="30" as="alternateBounds"/>
-                    </mxGeometry>
-                </mxCell>
-                <mxCell id="116" value="name" style="shape=partialRectangle;connectable=0;fillColor=none;top=0;left=0;bottom=0;right=0;align=left;spacingLeft=6;overflow=hidden;whiteSpace=wrap;html=1;" parent="114" vertex="1">
-                    <mxGeometry x="30" width="150" height="30" as="geometry">
-                        <mxRectangle width="150" height="30" as="alternateBounds"/>
-                    </mxGeometry>
-                </mxCell>
                 <mxCell id="117" value="" style="shape=tableRow;horizontal=0;startSize=0;swimlaneHead=0;swimlaneBody=0;fillColor=none;collapsible=0;dropTarget=0;points=[[0,0.5],[1,0.5]];portConstraint=eastwest;top=0;left=0;right=0;bottom=0;" parent="110" vertex="1">
-                    <mxGeometry y="90" width="180" height="30" as="geometry"/>
+                    <mxGeometry y="60" width="180" height="30" as="geometry"/>
                 </mxCell>
                 <mxCell id="118" value="" style="shape=partialRectangle;connectable=0;fillColor=none;top=0;left=0;bottom=0;right=0;editable=1;overflow=hidden;whiteSpace=wrap;html=1;" parent="117" vertex="1">
                     <mxGeometry width="30" height="30" as="geometry">
@@ -397,47 +384,8 @@
                         <mxRectangle width="150" height="30" as="alternateBounds"/>
                     </mxGeometry>
                 </mxCell>
-                <mxCell id="120" value="" style="shape=tableRow;horizontal=0;startSize=0;swimlaneHead=0;swimlaneBody=0;fillColor=none;collapsible=0;dropTarget=0;points=[[0,0.5],[1,0.5]];portConstraint=eastwest;top=0;left=0;right=0;bottom=0;" parent="110" vertex="1">
-                    <mxGeometry y="120" width="180" height="30" as="geometry"/>
-                </mxCell>
-                <mxCell id="121" value="" style="shape=partialRectangle;connectable=0;fillColor=none;top=0;left=0;bottom=0;right=0;editable=1;overflow=hidden;whiteSpace=wrap;html=1;" parent="120" vertex="1">
-                    <mxGeometry width="30" height="30" as="geometry">
-                        <mxRectangle width="30" height="30" as="alternateBounds"/>
-                    </mxGeometry>
-                </mxCell>
-                <mxCell id="122" value="avatar_url" style="shape=partialRectangle;connectable=0;fillColor=none;top=0;left=0;bottom=0;right=0;align=left;spacingLeft=6;overflow=hidden;whiteSpace=wrap;html=1;" parent="120" vertex="1">
-                    <mxGeometry x="30" width="150" height="30" as="geometry">
-                        <mxRectangle width="150" height="30" as="alternateBounds"/>
-                    </mxGeometry>
-                </mxCell>
-                <mxCell id="173" value="" style="shape=tableRow;horizontal=0;startSize=0;swimlaneHead=0;swimlaneBody=0;fillColor=none;collapsible=0;dropTarget=0;points=[[0,0.5],[1,0.5]];portConstraint=eastwest;top=0;left=0;right=0;bottom=0;" parent="110" vertex="1">
-                    <mxGeometry y="150" width="180" height="30" as="geometry"/>
-                </mxCell>
-                <mxCell id="174" value="" style="shape=partialRectangle;connectable=0;fillColor=none;top=0;left=0;bottom=0;right=0;editable=1;overflow=hidden;whiteSpace=wrap;html=1;" parent="173" vertex="1">
-                    <mxGeometry width="30" height="30" as="geometry">
-                        <mxRectangle width="30" height="30" as="alternateBounds"/>
-                    </mxGeometry>
-                </mxCell>
-                <mxCell id="175" value="public_favorites_count" style="shape=partialRectangle;connectable=0;fillColor=none;top=0;left=0;bottom=0;right=0;align=left;spacingLeft=6;overflow=hidden;whiteSpace=wrap;html=1;" parent="173" vertex="1">
-                    <mxGeometry x="30" width="150" height="30" as="geometry">
-                        <mxRectangle width="150" height="30" as="alternateBounds"/>
-                    </mxGeometry>
-                </mxCell>
-                <mxCell id="148" value="" style="shape=tableRow;horizontal=0;startSize=0;swimlaneHead=0;swimlaneBody=0;fillColor=none;collapsible=0;dropTarget=0;points=[[0,0.5],[1,0.5]];portConstraint=eastwest;top=0;left=0;right=0;bottom=0;" parent="110" vertex="1">
-                    <mxGeometry y="180" width="180" height="30" as="geometry"/>
-                </mxCell>
-                <mxCell id="149" value="" style="shape=partialRectangle;connectable=0;fillColor=none;top=0;left=0;bottom=0;right=0;editable=1;overflow=hidden;whiteSpace=wrap;html=1;" parent="148" vertex="1">
-                    <mxGeometry width="30" height="30" as="geometry">
-                        <mxRectangle width="30" height="30" as="alternateBounds"/>
-                    </mxGeometry>
-                </mxCell>
-                <mxCell id="150" value="permalink_url" style="shape=partialRectangle;connectable=0;fillColor=none;top=0;left=0;bottom=0;right=0;align=left;spacingLeft=6;overflow=hidden;whiteSpace=wrap;html=1;" parent="148" vertex="1">
-                    <mxGeometry x="30" width="150" height="30" as="geometry">
-                        <mxRectangle width="150" height="30" as="alternateBounds"/>
-                    </mxGeometry>
-                </mxCell>
                 <mxCell id="182" value="" style="shape=tableRow;horizontal=0;startSize=0;swimlaneHead=0;swimlaneBody=0;fillColor=none;collapsible=0;dropTarget=0;points=[[0,0.5],[1,0.5]];portConstraint=eastwest;top=0;left=0;right=0;bottom=0;" parent="110" vertex="1">
-                    <mxGeometry y="210" width="180" height="30" as="geometry"/>
+                    <mxGeometry y="90" width="180" height="30" as="geometry"/>
                 </mxCell>
                 <mxCell id="183" value="" style="shape=partialRectangle;connectable=0;fillColor=none;top=0;left=0;bottom=0;right=0;editable=1;overflow=hidden;whiteSpace=wrap;html=1;" parent="182" vertex="1">
                     <mxGeometry width="30" height="30" as="geometry">


### PR DESCRIPTION
SoundCloud 上でログインユーザーがフォローしているアーティストの一覧を返すAPIを実装しました。  また、取得したアーティスト情報を扱うために ValueObject を導入し、それにあわせてDB 設計を変更しました

-  SoundCloud アーティストの情報を表現する `ArtistInfo` VO を追加
- `artists` テーブルの設計を変更し、`soundcloud_user_id`（外部ID）のみを保存
  - アーティストの公開プロフィール情報はDBに保存せず、APIから動的に取得する設計
  - SoundCloud API のポリシーに準拠