### PR TITLE
feat(api): implement artist search endpoint

### DIFF
--- a/backend/src/application/usecase/searchArtistsUseCase.ts
+++ b/backend/src/application/usecase/searchArtistsUseCase.ts
@@ -1,0 +1,25 @@
+import { TokenApplicationService } from "../applicationSercices/tokenApplicationService";
+import { ArtistApiRepository } from "../../domain/interfaces/artistApiRepository";
+
+export class SearchArtistsUseCase {
+  constructor(
+    private readonly _tokenApplicationService: TokenApplicationService,
+    private readonly _artistApiRepository: ArtistApiRepository
+  ) {}
+
+  async run(sessionId: string, artistName: string) {
+    // 有効なトークンを取得
+    const validToken = await this._tokenApplicationService.getValidTokenOrThrow(
+      sessionId
+    );
+
+    //　APIでアーティストを検索
+    const artists = await this._artistApiRepository.searchArtist(
+      validToken.accessToken,
+      artistName
+    );
+
+    // 検索結果 を コントローラーに返す
+    return artists;
+  }
+}

--- a/backend/src/domain/interfaces/artistApiRepository.ts
+++ b/backend/src/domain/interfaces/artistApiRepository.ts
@@ -1,0 +1,8 @@
+import { ArtistInfo } from "../valueObjects/artistInfo";
+
+export interface ArtistApiRepository {
+  searchArtist(
+    accessToken: string,
+    artistName: string
+  ): Promise<Array<ArtistInfo>>;
+}

--- a/backend/src/infrastructure/api/artistSoundCloudRepository.ts
+++ b/backend/src/infrastructure/api/artistSoundCloudRepository.ts
@@ -1,0 +1,45 @@
+import { ArtistApiRepository } from "../../domain/interfaces/artistApiRepository";
+import { ArtistInfo } from "../../domain/valueObjects/artistInfo";
+import { config } from "../../config/config";
+import axios from "axios";
+
+export class ArtistSoundCloudRepository implements ArtistApiRepository {
+  // アーティストを検索
+  async searchArtist(
+    accessToken: string,
+    artistName: string
+  ): Promise<Array<ArtistInfo>> {
+    const endPoint = `${config.API_BASE_URL}/search/users`;
+
+    const headers = {
+      accept: "application/json; charset=utf-8",
+      Authorization: accessToken,
+    };
+
+    const params = {
+      q: artistName,
+      limit: 5,
+    };
+
+    try {
+      const response = await axios.get(endPoint, {
+        headers: headers,
+        params: params,
+      });
+
+      return response.data.collection.map(
+        (artist: any) =>
+          new ArtistInfo(
+            artist.id,
+            artist.name,
+            artist.avatar_url,
+            artist.public_favorites_count,
+            artist.permalink_url
+          )
+      );
+    } catch (error) {
+      console.error("searchArtist request failed:", error);
+      throw new Error("SearchArtist request failed");
+    }
+  }
+}

--- a/backend/src/presentation/controller/artistController.ts
+++ b/backend/src/presentation/controller/artistController.ts
@@ -1,0 +1,37 @@
+import { SearchArtistsUseCase } from "../../application/usecase/searchArtistsUseCase";
+import { Request, Response } from "express";
+
+export class ArtistController {
+  constructor(private readonly _searchArtistsUseCase: SearchArtistsUseCase) {}
+
+  async searchArtists(req: Request, res: Response): Promise<void> {
+    // リクエスト
+    const sessionId = req.cookies.sessionId;
+    const artistNameRaw = req.query.artistName;
+
+    if (typeof artistNameRaw !== "string") {
+      res.status(400).json({ error: "Missing 'artistName' query parameter" });
+      return;
+    }
+
+    const decodedArtistName = decodeURIComponent(artistNameRaw);
+
+    // ユースケース
+    const artists = await this._searchArtistsUseCase.run(
+      sessionId,
+      decodedArtistName
+    );
+
+    // レスポンス
+    res
+      .cookie("sessionId", sessionId, {
+        httpOnly: true,
+        secure: true,
+        sameSite: "none", // TODO：　時間があればCSRF対策　で　csurfを導入する
+      })
+      .status(200)
+      .json({
+        artists: artists,
+      });
+  }
+}

--- a/backend/src/presentation/di/artistController.di.ts
+++ b/backend/src/presentation/di/artistController.di.ts
@@ -1,0 +1,16 @@
+import { ArtistController } from "../controller/artistController";
+import { SearchArtistsUseCase } from "../../application/usecase/searchArtistsUseCase";
+import { TokenApplicationService } from "../../application/applicationSercices/tokenApplicationService";
+import { SessionRedisRepository } from "../../infrastructure/redis/sessionRedisRepository";
+import { TokenSoundCloudRepository } from "../../infrastructure/api/tokenSoundCloudRepository";
+import { ArtistSoundCloudRepository } from "../../infrastructure/api/artistSoundCloudRepository";
+
+export const artistController = new ArtistController(
+  new SearchArtistsUseCase(
+    new TokenApplicationService(
+      new SessionRedisRepository(),
+      new TokenSoundCloudRepository()
+    ),
+    new ArtistSoundCloudRepository()
+  )
+);

--- a/backend/src/presentation/router/artistRouter.ts
+++ b/backend/src/presentation/router/artistRouter.ts
@@ -1,0 +1,7 @@
+import { Router } from "express";
+import { asyncHandler } from "../../middleware/asyncHandler";
+import { artistController } from "../di/artistController.di";
+
+export const artistRouter = Router();
+
+artistRouter.get("/api/artists", asyncHandler(artistController.searchArtists));


### PR DESCRIPTION
アーティスト名で検索し、該当するアーティスト情報を取得するエンドポイントを実装しました。
クエリパラメータ `artistName` を受け取り、SoundCloud API を用いて最大5件まで返します。

