### PR TITLE
feat(api): implement follow artist endpoint

### DIFF
--- a/backend/src/application/usecase/followArtistUseCase.ts
+++ b/backend/src/application/usecase/followArtistUseCase.ts
@@ -1,0 +1,22 @@
+import { UserApiRepository } from "../../domain/interfaces/userApiRepository";
+import { TokenApplicationService } from "../applicationSercices/tokenApplicationService";
+
+export class FollowArtistUseCase {
+  constructor(
+    private readonly _tokenApplicationService: TokenApplicationService,
+    private readonly _userApiRepository: UserApiRepository
+  ) {}
+
+  async run(sessionId: string, soundcloudArtistId: number): Promise<void> {
+    // 有効なトークンを取得
+    const validToken = await this._tokenApplicationService.getValidTokenOrThrow(
+      sessionId
+    );
+
+    // APIでアーティストをフォロー
+    await this._userApiRepository.followArtist(
+      validToken.accessToken,
+      soundcloudArtistId
+    );
+  }
+}

--- a/backend/src/domain/interfaces/userApiRepository.ts
+++ b/backend/src/domain/interfaces/userApiRepository.ts
@@ -4,4 +4,5 @@ import { ArtistInfo } from "../valueObjects/artistInfo";
 export interface UserApiRepository {
   fetchUser(accessToken: string): Promise<UserInfo>;
   fetchFollowings(accessToken: string): Promise<Array<ArtistInfo>>;
+  followArtist(accessToken: string, soundcloudArtistId: number): Promise<void>;
 }

--- a/backend/src/infrastructure/api/userSoundCloudRepository.ts
+++ b/backend/src/infrastructure/api/userSoundCloudRepository.ts
@@ -8,6 +8,7 @@ export class UserSoundCloudRepository implements UserApiRepository {
   // ユーザー情報を取得
   async fetchUser(accessToken: string): Promise<UserInfo> {
     const endPoint = `${config.API_BASE_URL}/me`;
+
     const headers = {
       accept: "application/json; charset=utf-8",
       Authorization: accessToken,
@@ -29,9 +30,10 @@ export class UserSoundCloudRepository implements UserApiRepository {
     }
   }
 
-  // アーティスト情報を取得
+  // フォロー中のアーティスト情報を取得
   async fetchFollowings(accessToken: string): Promise<Array<ArtistInfo>> {
     const endPoint = `${config.API_BASE_URL}/me/followings`;
+
     const headers = {
       accept: "application/json; charset=utf-8",
       Authorization: accessToken,
@@ -53,6 +55,26 @@ export class UserSoundCloudRepository implements UserApiRepository {
     } catch (error) {
       console.error("fetchFollowings request failed:", error);
       throw new Error("FetchFollowings request failed");
+    }
+  }
+
+  // アーティストをフォローする
+  async followArtist(
+    accessToken: string,
+    soundcloudArtistId: number
+  ): Promise<void> {
+    const endPoint = `${config.API_BASE_URL}/me/followings/${soundcloudArtistId}`;
+
+    const headers = {
+      accept: "application/json; charset=utf-8",
+      Authorization: accessToken,
+    };
+
+    try {
+      await axios.put(endPoint, { headers: headers });
+    } catch (error) {
+      console.error("followingArtist request failed:", error);
+      throw new Error("FollowingArtist request failed");
     }
   }
 }

--- a/backend/src/presentation/controller/artistController.ts
+++ b/backend/src/presentation/controller/artistController.ts
@@ -14,13 +14,10 @@ export class ArtistController {
       return;
     }
 
-    const decodedArtistName = decodeURIComponent(artistNameRaw);
+    const artistName = decodeURIComponent(artistNameRaw);
 
     // ユースケース
-    const artists = await this._searchArtistsUseCase.run(
-      sessionId,
-      decodedArtistName
-    );
+    const artists = await this._searchArtistsUseCase.run(sessionId, artistName);
 
     // レスポンス
     res

--- a/backend/src/presentation/controller/userController.ts
+++ b/backend/src/presentation/controller/userController.ts
@@ -1,16 +1,21 @@
 import { Request, Response } from "express";
 import { FetchMyFollowingsUseCase } from "../../application/usecase/fetchMyFollowingsUseCase";
+import { FollowArtistUseCase } from "../../application/usecase/followArtistUseCase";
 
 export class UserController {
   constructor(
-    private readonly _fetchMyFollowingsUseCase: FetchMyFollowingsUseCase
+    private readonly _fetchMyFollowingsUseCase: FetchMyFollowingsUseCase,
+    private readonly _followArtistUseCase: FollowArtistUseCase
   ) {}
 
-  async getMyFollowings(req: Request, res: Response): Promise<void> {
+  // フォロー中のアーティストを取得する
+  async fetchMyFollowings(req: Request, res: Response): Promise<void> {
     // リクエスト
     const sessionId = req.cookies.sessionId;
+
     // ユースケース
     const followings = await this._fetchMyFollowingsUseCase.run(sessionId);
+
     // レスポンス
     res
       .cookie("sessionId", sessionId, {
@@ -21,6 +26,37 @@ export class UserController {
       .status(200)
       .json({
         followings: followings,
+      });
+  }
+
+  // アーティストをフォローする
+  async followArtist(req: Request, res: Response): Promise<void> {
+    // リクエスト
+    const sessionId = req.cookies.sessionId;
+    const soundcloudArtistIdRaw = req.params.soundcloudArtistId;
+
+    if (typeof soundcloudArtistIdRaw !== "string") {
+      res.status(400).json({ error: "Missing 'soundcloudArtistId' parameter" });
+      return;
+    }
+
+    const soundcloudArtistId = Number(
+      decodeURIComponent(soundcloudArtistIdRaw)
+    );
+
+    // ユースケース
+    await this._followArtistUseCase.run(sessionId, soundcloudArtistId);
+
+    // レスポンス
+    res
+      .cookie("sessionId", sessionId, {
+        httpOnly: true,
+        secure: true,
+        sameSite: "none", // TODO：　時間があればCSRF対策　で　csurfを導入する
+      })
+      .status(200)
+      .json({
+        message: "Followed artist successfully",
       });
   }
 }

--- a/backend/src/presentation/router/userRouter.ts
+++ b/backend/src/presentation/router/userRouter.ts
@@ -4,7 +4,14 @@ import { userController } from "../di/userController.di";
 
 export const userRouter = Router();
 
+// フォロー中のアーティストを取得するエンドポイント
 userRouter.get(
-  "/api/users/following",
-  asyncHandler(userController.getMyFollowings)
+  "/api/users/followings",
+  asyncHandler(userController.fetchMyFollowings)
+);
+
+// アーティストをフォローするエンドポイント
+userRouter.put(
+  "/api/users/followings/:soundcloudArtistId",
+  asyncHandler(userController.followArtist)
 );

--- a/docs/openapi-draft.md
+++ b/docs/openapi-draft.md
@@ -38,7 +38,7 @@
 ```json
 [
   {
-    externalUserId: 12345
+    soundcloudArtistId: 12345
     name: Travis Sccott,
     avatarUrl: https:~,
     publicFavoritesCount: 123,
@@ -57,7 +57,7 @@
 ```json
 [
   {
-    externalUserId: 12345
+    soundcloudArtistId: 12345
     name: Travis Sccott,
     avatarUrl: https:~,
     publicFavoritesCount: 123,
@@ -67,7 +67,7 @@
 ]
 ```
 
-### PUT /api/users/followings/:artistId
+### PUT /api/users/followings/:soundcloudArtistId
 
 - 説明：SoundCloud でアーティストをフォローする
 - 認証：Cookie(sessionId)

--- a/docs/openapi-draft.md
+++ b/docs/openapi-draft.md
@@ -16,7 +16,7 @@
 
 ##　 API 設計
 
-### POST /api/auth
+### POST /api/auth/authorize
 
 - 説明：codeVerifier と code を送信する（Cookie に sessionId が返る）
 - 認証：Cookie(sessionId)
@@ -29,73 +29,74 @@
 }
 ```
 
-### GET /api/users/following
+### GET /api/users/followings
 
-- 説明：フォロ中のアーティストを取得する
+- 説明：SoundCloud でフォロ中のアーティストを取得する
 - 認証：Cookie(sessionId)
 - レスポンス：
 
 ```json
 [
   {
-    name: travis sccott,
-    avatar_url: https:~,
-    public_favorites_count: 123,
-    permalink_url: https:~,
+    externalUserId: 12345
+    name: Travis Sccott,
+    avatarUrl: https:~,
+    publicFavoritesCount: 123,
+    permalinkUrl: https:~,
   },
   ...
 ]
 ```
 
-### GET /api/artists/?name=travis+scott
+### GET /api/artists/`?artistName=Travis+Scott`
 
-- 説明：アーティストを取得する
+- 説明：SoundCloud でアーティストを検索する
 - 認証：Cookie(sessionId)
 - レスポンス：
 
 ```json
 [
   {
-    name: travis sccott,
-    avatar_url: https:~,
-    public_favorites_count: 123,
-    permalink_ural: https:~,
+    externalUserId: 12345
+    name: Travis Sccott,
+    avatarUrl: https:~,
+    publicFavoritesCount: 123,
+    permalinkUrl: https:~,
   },
   ...
 ]
 ```
 
-### PUT /api/users/following/:artists_id
+### PUT /api/users/followings/:artistId
 
-- 説明：アーティストをフォローする
+- 説明：SoundCloud でアーティストをフォローする
 - 認証：Cookie(sessionId)
-- レスポンス：
 
 ### GET /api/recommendations
 
-- 説明：レコメンドを取得する
+- 説明：楽曲レコメンドを取得する
 - 認証：Cookie(sessionId)
 - レスポンス：
 
 ```json
 [
-  { // APIで曲を再生する場合 (利用規約に注意)
-    track_title: FE!N,
-    artwork_url: https:~,
-    track_permalink_url: https:~,
-    artist_name: travis sccott,
-    avatar_url: https:~,
-    artist_permalink_url: https:~,
+  { // SoundCloud APIで曲を再生する場合 (APIポリシーに注意)
+    trackTitle: FE!N,
+    artworkUrl: https:~,
+    trackPermalinkUrl: https:~,
+    artistName: Travis Sccott,
+    avatarUrl: https:~,
+    artistPermalinkUrl: https:~,
     // ウィジェットで曲を再生する場合
-    widget_url: https:~,
+    widgetUrl: https:~,
   },
   ...
 ]
 ```
 
-### GET /api/recommendations/history
+### GET /api/recommendations/historys
 
-- 説明：レコメンド履歴を取得する
+- 説明：楽曲レコメンド履歴を取得する
 - 認証：Cookie(sessionId)
 - レスポンス：
 
@@ -106,7 +107,7 @@
     tracks: [
       {
       // ウィジェットで曲を再生する場合
-      widget_url: https:~,
+      widgetUrl: https:~,
       }
     ]
   },


### PR DESCRIPTION
SoundCloud アーティストをフォローするエンドポイントを実装しました。
指定された `soundcloudArtistId` を使って、SoundCloud API 経由でフォロー処理を行います。
