### PR TITLE
feat(rec): implement save recommendation logic with transaction

### DIFF
--- a/backend/src/application/applicationSercices/tokenApplicationService.ts
+++ b/backend/src/application/applicationSercices/tokenApplicationService.ts
@@ -39,4 +39,20 @@ export class TokenApplicationService {
     // 有効なトークンを返す
     return session.token;
   }
+
+  // ユーザーIDを取得
+  async getUserId(sessionId: string): Promise<number> {
+    // sessionId がなければ再ログインを要求
+    if (!sessionId) throw new Error("REAUTH_REQUIRED");
+
+    // セッションを取得
+    const session = await this._sessionRepository.get(sessionId);
+
+    // セッションが期限切れならば再ログインを要求
+    if (!session) {
+      throw new Error("REAUTH_REQUIRED");
+    }
+
+    return session.userId;
+  }
 }

--- a/backend/src/application/usecase/getRecommendationUseCase.ts
+++ b/backend/src/application/usecase/getRecommendationUseCase.ts
@@ -1,9 +1,10 @@
 import { TokenApplicationService } from "../applicationSercices/tokenApplicationService";
 import { UserApiRepository } from "../../domain/interfaces/userApiRepository";
 import { RecommendationDomainService } from "../../domain/domainServices/recommendationDomainService";
-import { Followings } from "../../domain/valueObjects/followings";
-import { TrackInfo } from "../../domain/valueObjects/trackInfo";
 import { RecommendationApplicationService } from "../applicationSercices/recommendationApplicationService";
+import { RecommendationDbRepository } from "../../domain/interfaces/recommendationDbRepository";
+import { Followings } from "../../domain/valueObjects/followings";
+import { Recommendation } from "../../domain/entities/recommendation";
 
 export class GetRecommendationUseCase {
   constructor(
@@ -40,16 +41,17 @@ export class GetRecommendationUseCase {
         10
       );
 
-    ////////　ここまで実装完了///////
+    // 取得した楽曲からレコメンドを作成
+    const userId = await this._tokenApplicationService.getUserId(sessionId);
+    const recommendation = new Recommendation(userId, tracks);
 
-    // 取得した楽曲からレコメンド作成 （Recommendation エンティティに変換（レコメンドIDなども付与））
-    const recommendation =
-      this._recommendationDomainService.createRecommendation(tracks); // Recommendationの構築が複雑であればFactoryを導入する
+    // レコメンドをDBに保存 (レコメンドIDを付与)
+    const recommendationEntity =
+      await this._recommendationDbRepository.saveAndReturnWithId(
+        recommendation
+      );
 
-    // レコメンド結果をDBに保存
-    await this._recommendationDbRepository.save(recommendation);
-
-    // レコメンド結果をコントローラーに返す
-    return recommendation; // DTOしてコントローラーに返す
+    // レコメンドをコントローラーに返す
+    return recommendationEntity;
   }
 }

--- a/backend/src/domain/entities/recommendation.ts
+++ b/backend/src/domain/entities/recommendation.ts
@@ -1,0 +1,17 @@
+import { TrackInfo } from "../valueObjects/trackInfo";
+
+export class Recommendation {
+  constructor(
+    private readonly _userId: number,
+    private readonly _tracks: TrackInfo[],
+    private readonly _id?: number // DB保存時に付与
+  ) {}
+
+  get userId() {
+    return this._userId;
+  }
+
+  get tracks() {
+    return this._tracks;
+  }
+}

--- a/backend/src/domain/interfaces/recommendationDbRepository.ts
+++ b/backend/src/domain/interfaces/recommendationDbRepository.ts
@@ -1,0 +1,5 @@
+import { Recommendation } from "../entities/recommendation";
+
+export interface RecommendationDbRepository {
+  saveAndReturnWithId(recommendation: Recommendation): Promise<Recommendation>;
+}

--- a/backend/src/domain/valueObjects/trackInfo.ts
+++ b/backend/src/domain/valueObjects/trackInfo.ts
@@ -8,4 +8,16 @@ export class TrackInfo {
     private readonly _permalinkUrl: string,
     private readonly _artist: ArtistInfo
   ) {}
+
+  get externalTrackId() {
+    return this._externalTrackId;
+  }
+
+  get permalinkUrl() {
+    return this._permalinkUrl;
+  }
+
+  get artist() {
+    return this._artist;
+  }
 }

--- a/backend/src/infrastructure/db/artistMysqlRepository.ts
+++ b/backend/src/infrastructure/db/artistMysqlRepository.ts
@@ -1,0 +1,37 @@
+import { ArtistInfo } from "../../domain/valueObjects/artistInfo";
+import mysql from "mysql2/promise";
+
+export class ArtistMysqlRepository {
+  // アーティストの存在確認と保存
+  async findOrCreateId(
+    transactionConn: mysql.PoolConnection,
+    artist: ArtistInfo
+  ): Promise<number> {
+    try {
+      // DBからアーティストを探す
+      const [artistSelectResults] = await transactionConn.execute<
+        mysql.RowDataPacket[]
+      >("SELECT id FROM artists WHERE soundcloud_artist_id = ?", [
+        artist.externalUserId,
+      ]);
+
+      // アーティストが登録済みならば artistId を返す
+      if (artistSelectResults[0]) {
+        return artistSelectResults[0].id;
+      }
+
+      // ユーザーが未登録ならば INSERT
+      const [artistInsertResults] =
+        await transactionConn.execute<mysql.ResultSetHeader>(
+          "INSERT INTO artists (soundcloud_artist_id) values (?)",
+          [artist.externalUserId]
+        );
+
+      // artistId を返す
+      return artistInsertResults.insertId;
+    } catch (error) {
+      console.error("findOrCreateArtistId request failed:", error);
+      throw new Error("FindOrCreateArtistId request failed");
+    }
+  }
+}

--- a/backend/src/infrastructure/db/recommendationMySQLRepository.ts
+++ b/backend/src/infrastructure/db/recommendationMySQLRepository.ts
@@ -1,0 +1,99 @@
+import { RecommendationDbRepository } from "../../domain/interfaces/recommendationDbRepository";
+import { ArtistMysqlRepository } from "./artistMysqlRepository";
+import { TrackMysqlRepository } from "./tracksMysqlRepository";
+import { Recommendation } from "../../domain/entities/recommendation";
+import { MysqlClient } from "./mysqlClient";
+import mysql from "mysql2/promise";
+
+export class RecommendationMySQLRepository
+  implements RecommendationDbRepository
+{
+  constructor(
+    private readonly _artistMysqlRepository: ArtistMysqlRepository,
+    private readonly _trackMysqlRepository: TrackMysqlRepository
+  ) {}
+
+  // レコメンドを作成
+  async saveAndReturnWithId(
+    recommendation: Recommendation
+  ): Promise<Recommendation> {
+    // poolから専用コネクションを取得
+    const transactionConn = await MysqlClient.getConnection();
+
+    try {
+      // トランザクション開始
+      await transactionConn.beginTransaction();
+
+      // テーブル間の依存関係に従って順番にIDを取得または保存
+      //　　楽曲IDを取得
+      const trackIds: number[] = await Promise.all(
+        recommendation.tracks.map(async (track) => {
+          // DBに アーティスト が存在するか確認し、なければ保存
+          const artistId = await this._artistMysqlRepository.findOrCreateId(
+            transactionConn,
+            track.artist
+          );
+          // DBに 楽曲 が存在するか確認し、なければ保存
+          const trackId = await this._trackMysqlRepository.findOrCreateId(
+            transactionConn,
+            track,
+            artistId
+          );
+          // 楽曲ID を返す
+          return trackId;
+        })
+      );
+
+      // レコメンドを保存
+      const [recommendationInsertResults] =
+        await transactionConn.execute<mysql.ResultSetHeader>(
+          "INSERT INTO recommendations (user_id) VALUES (?)",
+          [recommendation.userId]
+        );
+
+      // レコメンドIDを取得
+      const recommendationId = recommendationInsertResults.insertId;
+
+      // 中間テーブルを保存
+      await Promise.all(
+        trackIds.map(async (trackId) => {
+          await transactionConn.execute<mysql.ResultSetHeader>(
+            "INSERT INTO recommendations_tracks (recommendations_id, tracks_id, liked) VALUES (?, ?, false)",
+            [recommendationId, trackId]
+          );
+        })
+      );
+
+      // トランザクション終了
+      await transactionConn.commit();
+
+      // レコメンドエンティティにIDを付与して返す
+      return new Recommendation(
+        recommendation.userId,
+        recommendation.tracks,
+        recommendationId // IDを付与
+      );
+    } catch (error) {
+      // 失敗時にロールバック
+      if (transactionConn) {
+        try {
+          await transactionConn.rollback();
+        } catch (rollbackError) {
+          console.error("rollback failed:", rollbackError);
+        }
+      }
+
+      console.error("Recommendation: saveAndReturnWithId failed:", error);
+      throw new Error("Recommendation: SaveAndReturnWithId request failed");
+    } finally {
+      // コネクションを開放
+      if (transactionConn) {
+        try {
+          transactionConn.release();
+        } catch (releaseError) {
+          console.error("connection release failed:", releaseError);
+        }
+      }
+    }
+  }
+}

--- a/backend/src/infrastructure/db/tracksMysqlRepository.ts
+++ b/backend/src/infrastructure/db/tracksMysqlRepository.ts
@@ -1,0 +1,38 @@
+import { TrackInfo } from "../../domain/valueObjects/trackInfo";
+import mysql from "mysql2/promise";
+
+export class TrackMysqlRepository {
+  // 楽曲の存在確認と保存
+  async findOrCreateId(
+    transactionConn: mysql.PoolConnection,
+    track: TrackInfo,
+    artistId: number // 内部のID
+  ): Promise<number> {
+    try {
+      // 楽曲を探す
+      const [trackSelectResults] = await transactionConn.execute<
+        mysql.RowDataPacket[]
+      >("SELECT id FROM tracks WHERE soundcloud_track_id = ?", [
+        track.externalTrackId,
+      ]);
+
+      // 楽曲が登録済みならば trackId を返す
+      if (trackSelectResults[0]) {
+        return trackSelectResults[0].id;
+      }
+
+      // 楽曲が未登録ならば INSERT
+      const [trackInsertResults] =
+        await transactionConn.execute<mysql.ResultSetHeader>(
+          "INSERT INTO tracks (artist_id, soundcloud_track_id, permalink_url) values (?, ?, ?)",
+          [artistId, track.externalTrackId, track.permalinkUrl]
+        );
+
+      // trackId を返す
+      return trackInsertResults.insertId;
+    } catch (error) {
+      console.error("findOrCreateTrackId request failed:", error);
+      throw new Error("FindOrCreateTrackId request failed");
+    }
+  }
+}

--- a/backend/src/presentation/controller/recommendationController.ts
+++ b/backend/src/presentation/controller/recommendationController.ts
@@ -1,7 +1,10 @@
+import { GetRecommendationUseCase } from "../../application/usecase/getRecommendationUseCase";
 import { Request, Response } from "express";
 
 export class RecommendationController {
-  constructor() {}
+  constructor(
+    private readonly _getRecommendationUseCase: GetRecommendationUseCase
+  ) {}
 
   // レコメンドを取得する
   async getRecommendations(req: Request, res: Response): Promise<void> {
@@ -9,6 +12,7 @@ export class RecommendationController {
     const sessionId = req.cookies.sessionId;
 
     // ユースケース
+    const recommendation = await this._getRecommendationUseCase.run(sessionId);
 
     // レスポンス
     res
@@ -18,6 +22,6 @@ export class RecommendationController {
         sameSite: "none", // TODO：　時間があればCSRF対策　で　csurfを導入する
       })
       .status(200)
-      .json({});
+      .json({ recommendation: recommendation });
   }
 }

--- a/backend/src/presentation/di/recommendationController.di.ts
+++ b/backend/src/presentation/di/recommendationController.di.ts
@@ -1,3 +1,28 @@
 import { RecommendationController } from "../controller/recommendationController";
+import { GetRecommendationUseCase } from "../../application/usecase/getRecommendationUseCase";
+import { TokenApplicationService } from "../../application/applicationSercices/tokenApplicationService";
+import { SessionRedisRepository } from "../../infrastructure/redis/sessionRedisRepository";
+import { TokenSoundCloudRepository } from "../../infrastructure/api/tokenSoundCloudRepository";
+import { UserSoundCloudRepository } from "../../infrastructure/api/userSoundCloudRepository";
+import { RecommendationDomainService } from "../../domain/domainServices/recommendationDomainService";
+import { RecommendationApplicationService } from "../../application/applicationSercices/recommendationApplicationService";
+import { TrackSoundCloudRepository } from "../../infrastructure/api/trackSoundCloudRepository";
+import { RecommendationMySQLRepository } from "../../infrastructure/db/recommendationMySQLRepository";
+import { ArtistMysqlRepository } from "../../infrastructure/db/artistMysqlRepository";
+import { TrackMysqlRepository } from "../../infrastructure/db/tracksMysqlRepository";
 
-export const recommendationController = new RecommendationController();
+export const recommendationController = new RecommendationController(
+  new GetRecommendationUseCase(
+    new TokenApplicationService(
+      new SessionRedisRepository(),
+      new TokenSoundCloudRepository()
+    ),
+    new UserSoundCloudRepository(),
+    new RecommendationDomainService(),
+    new RecommendationApplicationService(new TrackSoundCloudRepository()),
+    new RecommendationMySQLRepository(
+      new ArtistMysqlRepository(),
+      new TrackMysqlRepository()
+    )
+  )
+);

--- a/docs/er-diagram.drawio
+++ b/docs/er-diagram.drawio
@@ -1,6 +1,6 @@
 <mxfile host="65bd71144e">
     <diagram id="MVZLGIK-1uPKz9GJWDl0" name="ページ1">
-        <mxGraphModel dx="776" dy="379" grid="1" gridSize="10" guides="1" tooltips="1" connect="1" arrows="1" fold="1" page="1" pageScale="1" pageWidth="827" pageHeight="1169" math="0" shadow="0">
+        <mxGraphModel dx="476" dy="322" grid="1" gridSize="10" guides="1" tooltips="1" connect="1" arrows="1" fold="1" page="1" pageScale="1" pageWidth="827" pageHeight="1169" math="0" shadow="0">
             <root>
                 <mxCell id="0"/>
                 <mxCell id="1" parent="0"/>
@@ -181,7 +181,7 @@
                     <mxGeometry x="80" y="420" width="150" height="80" as="geometry"/>
                 </mxCell>
                 <mxCell id="84" value="recommendations" style="shape=table;startSize=30;container=1;collapsible=1;childLayout=tableLayout;fixedRows=1;rowLines=0;fontStyle=1;align=center;resizeLast=1;html=1;" parent="1" vertex="1">
-                    <mxGeometry x="330" y="490" width="180" height="180" as="geometry"/>
+                    <mxGeometry x="330" y="490" width="180" height="120" as="geometry"/>
                 </mxCell>
                 <mxCell id="85" value="" style="shape=tableRow;horizontal=0;startSize=0;swimlaneHead=0;swimlaneBody=0;fillColor=none;collapsible=0;dropTarget=0;points=[[0,0.5],[1,0.5]];portConstraint=eastwest;top=0;left=0;right=0;bottom=1;" parent="84" vertex="1">
                     <mxGeometry y="30" width="180" height="30" as="geometry"/>
@@ -209,34 +209,8 @@
                         <mxRectangle width="150" height="30" as="alternateBounds"/>
                     </mxGeometry>
                 </mxCell>
-                <mxCell id="91" value="" style="shape=tableRow;horizontal=0;startSize=0;swimlaneHead=0;swimlaneBody=0;fillColor=none;collapsible=0;dropTarget=0;points=[[0,0.5],[1,0.5]];portConstraint=eastwest;top=0;left=0;right=0;bottom=0;" parent="84" vertex="1">
-                    <mxGeometry y="90" width="180" height="30" as="geometry"/>
-                </mxCell>
-                <mxCell id="92" value="" style="shape=partialRectangle;connectable=0;fillColor=none;top=0;left=0;bottom=0;right=0;editable=1;overflow=hidden;whiteSpace=wrap;html=1;" parent="91" vertex="1">
-                    <mxGeometry width="30" height="30" as="geometry">
-                        <mxRectangle width="30" height="30" as="alternateBounds"/>
-                    </mxGeometry>
-                </mxCell>
-                <mxCell id="93" value="method" style="shape=partialRectangle;connectable=0;fillColor=none;top=0;left=0;bottom=0;right=0;align=left;spacingLeft=6;overflow=hidden;whiteSpace=wrap;html=1;" parent="91" vertex="1">
-                    <mxGeometry x="30" width="150" height="30" as="geometry">
-                        <mxRectangle width="150" height="30" as="alternateBounds"/>
-                    </mxGeometry>
-                </mxCell>
-                <mxCell id="94" value="" style="shape=tableRow;horizontal=0;startSize=0;swimlaneHead=0;swimlaneBody=0;fillColor=none;collapsible=0;dropTarget=0;points=[[0,0.5],[1,0.5]];portConstraint=eastwest;top=0;left=0;right=0;bottom=0;" parent="84" vertex="1">
-                    <mxGeometry y="120" width="180" height="30" as="geometry"/>
-                </mxCell>
-                <mxCell id="95" value="" style="shape=partialRectangle;connectable=0;fillColor=none;top=0;left=0;bottom=0;right=0;editable=1;overflow=hidden;whiteSpace=wrap;html=1;" parent="94" vertex="1">
-                    <mxGeometry width="30" height="30" as="geometry">
-                        <mxRectangle width="30" height="30" as="alternateBounds"/>
-                    </mxGeometry>
-                </mxCell>
-                <mxCell id="96" value="track_count" style="shape=partialRectangle;connectable=0;fillColor=none;top=0;left=0;bottom=0;right=0;align=left;spacingLeft=6;overflow=hidden;whiteSpace=wrap;html=1;" parent="94" vertex="1">
-                    <mxGeometry x="30" width="150" height="30" as="geometry">
-                        <mxRectangle width="150" height="30" as="alternateBounds"/>
-                    </mxGeometry>
-                </mxCell>
                 <mxCell id="142" value="" style="shape=tableRow;horizontal=0;startSize=0;swimlaneHead=0;swimlaneBody=0;fillColor=none;collapsible=0;dropTarget=0;points=[[0,0.5],[1,0.5]];portConstraint=eastwest;top=0;left=0;right=0;bottom=0;" parent="84" vertex="1">
-                    <mxGeometry y="150" width="180" height="30" as="geometry"/>
+                    <mxGeometry y="90" width="180" height="30" as="geometry"/>
                 </mxCell>
                 <mxCell id="143" value="" style="shape=partialRectangle;connectable=0;fillColor=none;top=0;left=0;bottom=0;right=0;editable=1;overflow=hidden;whiteSpace=wrap;html=1;" parent="142" vertex="1">
                     <mxGeometry width="30" height="30" as="geometry">
@@ -298,7 +272,7 @@
                         <mxRectangle width="30" height="30" as="alternateBounds"/>
                     </mxGeometry>
                 </mxCell>
-                <mxCell id="169" value="widget_url" style="shape=partialRectangle;connectable=0;fillColor=none;top=0;left=0;bottom=0;right=0;align=left;spacingLeft=6;overflow=hidden;whiteSpace=wrap;html=1;" parent="167" vertex="1">
+                <mxCell id="169" value="permalink_url" style="shape=partialRectangle;connectable=0;fillColor=none;top=0;left=0;bottom=0;right=0;align=left;spacingLeft=6;overflow=hidden;whiteSpace=wrap;html=1;" parent="167" vertex="1">
                     <mxGeometry x="30" width="150" height="30" as="geometry">
                         <mxRectangle width="150" height="30" as="alternateBounds"/>
                     </mxGeometry>


### PR DESCRIPTION
レコメンド機能において、RecommendationエンティティをDBに保存する処理を実装しました。

- ユーザーIDと10曲のTrackInfoからRecommendationエンティティを構築
- レコメンドテーブルの依存関係に従って、アーティスト、楽曲、レコメンド中間テーブルの保存処理を実装
- トランザクションを用いて、関連テーブルを一括で整合的に保存
- 保存後、recommendationIdを付与したエンティティを返す