### PR TITLE
feat(like): implement like tracks logic

### DIFF
--- a/backend/src/application/usecase/getHistorysUseCase.ts
+++ b/backend/src/application/usecase/getHistorysUseCase.ts
@@ -1,10 +1,10 @@
 import { SessionRepository } from "../../domain/interfaces/sessionRepository";
-import { HistoryRepository } from "../../domain/interfaces/historyRepository";
+import { HistoryDbRepository } from "../../domain/interfaces/historyDbRepository";
 
 export class GetHistorysUseCase {
   constructor(
     private readonly _sessionRepository: SessionRepository,
-    private readonly _historyRepository: HistoryRepository
+    private readonly _historyDbRepository: HistoryDbRepository
   ) {}
 
   async run(sessionId: string) {
@@ -15,7 +15,7 @@ export class GetHistorysUseCase {
     const userId = session.userId;
 
     // レコメンド履歴を取得
-    const historys = await this._historyRepository.get(userId, 20);
+    const historys = await this._historyDbRepository.get(userId, 20);
 
     // レコメンド履歴をコントローラーに返す
     return historys;

--- a/backend/src/application/usecase/likeTracksUseCase.ts
+++ b/backend/src/application/usecase/likeTracksUseCase.ts
@@ -1,0 +1,51 @@
+import { TokenApplicationService } from "../applicationSercices/tokenApplicationService";
+import { TrackDbRepository } from "../../domain/interfaces/trackDbRepository";
+import { LikeApiRepository } from "../../domain/interfaces/likeApiRepository";
+import { LikeDbRepository } from "../../domain/interfaces/likeDbRepository";
+
+export class LikeTracksUseCase {
+  constructor(
+    private readonly _tokenApplicationService: TokenApplicationService,
+    private readonly _trackDbRepository: TrackDbRepository,
+    private readonly _likeApiRepository: LikeApiRepository,
+    private readonly _likeDbRepository: LikeDbRepository
+  ) {}
+
+  async run(
+    sessionId: string,
+    recommendationId: number,
+    trackIds: number[]
+  ): Promise<void> {
+    // 有効なトークンを取得
+    const validToken = await this._tokenApplicationService.getValidTokenOrThrow(
+      sessionId
+    );
+
+    // いいね楽曲の外部IDを取得
+    const externalTrackIds: number[] = await Promise.all(
+      trackIds.map(
+        async (trackId) =>
+          await this._trackDbRepository.getExternalTrackId(trackId)
+      )
+    );
+
+    // APIで対象の楽曲をいいね
+    await Promise.all(
+      externalTrackIds.map(
+        async (externalTrackId) =>
+          await this._likeApiRepository.likeTrack(
+            validToken.accessToken,
+            externalTrackId
+          )
+      )
+    );
+
+    // DBにいいねを記録
+    await Promise.all(
+      trackIds.map(
+        async (trackId) =>
+          await this._likeDbRepository.save(recommendationId, trackId)
+      )
+    );
+  }
+}

--- a/backend/src/domain/interfaces/historyDbRepository.ts
+++ b/backend/src/domain/interfaces/historyDbRepository.ts
@@ -1,5 +1,5 @@
 import { RecommendationRecord } from "../entities/recommendationRecord";
 
-export interface HistoryRepository {
+export interface HistoryDbRepository {
   get(userId: number, limit: number): Promise<RecommendationRecord[]>;
 }

--- a/backend/src/domain/interfaces/likeApiRepository.ts
+++ b/backend/src/domain/interfaces/likeApiRepository.ts
@@ -1,0 +1,3 @@
+export interface LikeApiRepository {
+  likeTrack(accessToken: string, externalTrackId: number): Promise<void>;
+}

--- a/backend/src/domain/interfaces/likeDbRepository.ts
+++ b/backend/src/domain/interfaces/likeDbRepository.ts
@@ -1,0 +1,3 @@
+export interface LikeDbRepository {
+  save(recommendationId: number, trackId: number): Promise<void>;
+}

--- a/backend/src/domain/interfaces/trackDbRepository.ts
+++ b/backend/src/domain/interfaces/trackDbRepository.ts
@@ -1,0 +1,3 @@
+export interface TrackDbRepository {
+  getExternalTrackId(trackId: number): Promise<number>;
+}

--- a/backend/src/infrastructure/api/artistSoundCloudRepository.ts
+++ b/backend/src/infrastructure/api/artistSoundCloudRepository.ts
@@ -13,7 +13,7 @@ export class ArtistSoundCloudRepository implements ArtistApiRepository {
 
     const headers = {
       accept: "application/json; charset=utf-8",
-      Authorization: accessToken,
+      Authorization: `OAuth ${accessToken}`,
     };
 
     const params = {

--- a/backend/src/infrastructure/api/likeSoundCloudRepository.ts
+++ b/backend/src/infrastructure/api/likeSoundCloudRepository.ts
@@ -1,0 +1,23 @@
+import { config } from "../../config/config";
+import axios from "axios";
+
+export class LikeSoundCloudRepository {
+  async likeTrack(
+    accessToken: string,
+    soundcloudTrackId: number
+  ): Promise<void> {
+    const endPoint = `${config.API_BASE_URL}/likes/tracks/${soundcloudTrackId}`;
+
+    const headers = {
+      accept: "application/json; charset=utf-8",
+      Authorization: `OAuth ${accessToken}`,
+    };
+
+    try {
+      await axios.post(endPoint, undefined, { headers: headers });
+    } catch (error) {
+      console.error("likeTrack request failed:", error);
+      throw new Error("LikeTrack request failed");
+    }
+  }
+}

--- a/backend/src/infrastructure/api/trackSoundCloudRepository.ts
+++ b/backend/src/infrastructure/api/trackSoundCloudRepository.ts
@@ -14,7 +14,7 @@ export class TrackSoundCloudRepository {
 
     const headers = {
       accept: "application/json; charset=utf-8",
-      Authorization: accessToken,
+      Authorization: `OAuth ${accessToken}`,
     };
 
     const initialParams = {

--- a/backend/src/infrastructure/api/userSoundCloudRepository.ts
+++ b/backend/src/infrastructure/api/userSoundCloudRepository.ts
@@ -11,7 +11,7 @@ export class UserSoundCloudRepository implements UserApiRepository {
 
     const headers = {
       accept: "application/json; charset=utf-8",
-      Authorization: accessToken,
+      Authorization: `OAuth ${accessToken}`,
     };
 
     try {
@@ -36,7 +36,7 @@ export class UserSoundCloudRepository implements UserApiRepository {
 
     const headers = {
       accept: "application/json; charset=utf-8",
-      Authorization: accessToken,
+      Authorization: `OAuth ${accessToken}`,
     };
 
     try {
@@ -67,7 +67,7 @@ export class UserSoundCloudRepository implements UserApiRepository {
 
     const headers = {
       accept: "application/json; charset=utf-8",
-      Authorization: accessToken,
+      Authorization: `OAuth ${accessToken}`,
     };
 
     try {

--- a/backend/src/infrastructure/db/historyMysqlRepository.ts
+++ b/backend/src/infrastructure/db/historyMysqlRepository.ts
@@ -1,10 +1,10 @@
-import { HistoryRepository } from "../../domain/interfaces/historyRepository";
+import { HistoryDbRepository } from "../../domain/interfaces/historyDbRepository";
 import { RecommendationRecord } from "../../domain/entities/recommendationRecord";
 import { MysqlClient } from "./mysqlClient";
 import mysql from "mysql2/promise";
 import { RecordedTrack } from "../../domain/entities/recordedTrack";
 
-export class HistoryMysqlRepository implements HistoryRepository {
+export class HistoryMysqlRepository implements HistoryDbRepository {
   // レコメンド履歴を取得
   async get(userId: number, limit: number): Promise<RecommendationRecord[]> {
     try {

--- a/backend/src/infrastructure/db/likeMysqlRepository.ts
+++ b/backend/src/infrastructure/db/likeMysqlRepository.ts
@@ -1,0 +1,29 @@
+import { MysqlClient } from "./mysqlClient";
+import mysql from "mysql2/promise";
+
+export class LikeMysqlRepository {
+  // いいねを記録
+  async save(recommendationId: number, trackId: number): Promise<void> {
+    try {
+      const [updateLikeResult] =
+        await MysqlClient.execute<mysql.ResultSetHeader>(
+          `
+        UPDATE recommendations_tracks 
+        SET was_liked = TRUE 
+        WHERE recommendations_id = ? AND tracks_id = ?
+        `,
+          [recommendationId, trackId]
+        );
+
+      if (updateLikeResult.affectedRows === 0) {
+        console.error(
+          `matching record not found: recommendationId=${recommendationId}, trackId=${trackId}`
+        );
+        throw new Error("Matching record not found");
+      }
+    } catch (error) {
+      console.error("save like request failed:", error);
+      throw new Error("Save Like request failed");
+    }
+  }
+}

--- a/backend/src/infrastructure/db/tracksMysqlRepository.ts
+++ b/backend/src/infrastructure/db/tracksMysqlRepository.ts
@@ -1,7 +1,9 @@
-import { TrackInfo } from "../../domain/valueObjects/trackInfo";
+import { TrackDbRepository } from "../../domain/interfaces/trackDbRepository";
 import mysql from "mysql2/promise";
+import { TrackInfo } from "../../domain/valueObjects/trackInfo";
+import { MysqlClient } from "./mysqlClient";
 
-export class TrackMysqlRepository {
+export class TrackMysqlRepository implements TrackDbRepository {
   // 楽曲の存在確認と保存
   async findOrCreateId(
     transactionConn: mysql.PoolConnection,
@@ -33,6 +35,25 @@ export class TrackMysqlRepository {
     } catch (error) {
       console.error("findOrCreateTrackId request failed:", error);
       throw new Error("FindOrCreateTrackId request failed");
+    }
+  }
+
+  // soundcloudTrackIdを取得
+  async getExternalTrackId(trackId: number): Promise<number> {
+    try {
+      const [trackSelectResults] = await MysqlClient.execute<
+        mysql.RowDataPacket[]
+      >("SELECT soundcloud_track_id FROM tracks WHERE id = ?", [trackId]);
+
+      if (!trackSelectResults[0]) {
+        console.error(`matching record not found: trackId=${trackId}`);
+        throw new Error("Matching record not found");
+      }
+
+      return trackSelectResults[0].soundcloud_track_id;
+    } catch (error) {
+      console.error("getExternalTrackId request failed:", error);
+      throw new Error("GetExternalTrackId request failed");
     }
   }
 }

--- a/backend/src/presentation/controller/recommendationController.ts
+++ b/backend/src/presentation/controller/recommendationController.ts
@@ -1,11 +1,13 @@
 import { GetRecommendationUseCase } from "../../application/usecase/getRecommendationUseCase";
 import { GetHistorysUseCase } from "../../application/usecase/getHistorysUseCase";
+import { LikeTracksUseCase } from "../../application/usecase/likeTracksUseCase";
 import { Request, Response } from "express";
 
 export class RecommendationController {
   constructor(
     private readonly _getRecommendationUseCase: GetRecommendationUseCase,
-    private readonly _getHistorysUseCase: GetHistorysUseCase
+    private readonly _getHistorysUseCase: GetHistorysUseCase,
+    private readonly _likeTracksUseCase: LikeTracksUseCase
   ) {}
 
   // レコメンドを取得する
@@ -44,5 +46,35 @@ export class RecommendationController {
       })
       .status(200)
       .json({ historys: historys });
+  }
+
+  // レコメンド楽曲にいいねをする
+  async likeTracks(req: Request, res: Response): Promise<void> {
+    // リクエスト
+    const sessionId = req.cookies.sessionId;
+    const recommendationIdRaw = req.params.recommendationId;
+    const trackIds: number[] = req.body.trackIds;
+
+    if (typeof recommendationIdRaw !== "string") {
+      res.status(400).json({ error: "Missing 'recommendationId' parameter" });
+      return;
+    }
+
+    const recommendationId = Number(decodeURIComponent(recommendationIdRaw));
+
+    // ユースケース
+    await this._likeTracksUseCase.run(sessionId, recommendationId, trackIds);
+
+    // レスポンス
+    res
+      .cookie("sessionId", sessionId, {
+        httpOnly: true,
+        secure: true,
+        sameSite: "none", // TODO：　時間があればCSRF対策　で　csurfを導入する
+      })
+      .status(200)
+      .json({
+        message: "Like tracks successfully",
+      });
   }
 }

--- a/backend/src/presentation/di/recommendationController.di.ts
+++ b/backend/src/presentation/di/recommendationController.di.ts
@@ -12,8 +12,12 @@ import { ArtistMysqlRepository } from "../../infrastructure/db/artistMysqlReposi
 import { TrackMysqlRepository } from "../../infrastructure/db/tracksMysqlRepository";
 import { GetHistorysUseCase } from "../../application/usecase/getHistorysUseCase";
 import { HistoryMysqlRepository } from "../../infrastructure/db/historyMysqlRepository";
+import { LikeTracksUseCase } from "../../application/usecase/likeTracksUseCase";
+import { LikeSoundCloudRepository } from "../../infrastructure/api/likeSoundCloudRepository";
+import { LikeMysqlRepository } from "../../infrastructure/db/likeMysqlRepository";
 
 export const recommendationController = new RecommendationController(
+  // レコメンド取得
   new GetRecommendationUseCase(
     new TokenApplicationService(
       new SessionRedisRepository(),
@@ -27,8 +31,19 @@ export const recommendationController = new RecommendationController(
       new TrackMysqlRepository()
     )
   ),
+  // レコメンド履歴取得
   new GetHistorysUseCase(
     new SessionRedisRepository(),
     new HistoryMysqlRepository()
+  ),
+  // レコメンド楽曲をいいね
+  new LikeTracksUseCase(
+    new TokenApplicationService(
+      new SessionRedisRepository(),
+      new TokenSoundCloudRepository()
+    ),
+    new TrackMysqlRepository(),
+    new LikeSoundCloudRepository(),
+    new LikeMysqlRepository()
   )
 );

--- a/backend/src/presentation/router/recommendationRouter.ts
+++ b/backend/src/presentation/router/recommendationRouter.ts
@@ -15,3 +15,9 @@ recommendationRouter.get(
   "/api/recommendations/historys",
   asyncHandler(recommendationController.getHistorys)
 );
+
+// レコメンド楽曲にいいねをするエンドポイント
+recommendationRouter.post(
+  "/api/recommendations/:recommendationId/likes",
+  asyncHandler(recommendationController.likeTracks)
+);

--- a/docs/overall-flow.md
+++ b/docs/overall-flow.md
@@ -136,11 +136,7 @@
 
 ```json
 {
-  "likes": {
-    // 結果的に変更があったものだけを送る
-    "789(内部のtrackId)": true,
-    "790(内部のtrackId)": false,
-    ...
-  }
+    // いいねされたものだけを送る（falseからtrue）
+  "likes": [789(内部のtrackId), 790(内部のtrackId), ....]
 }
 ```


### PR DESCRIPTION
レコメンド画面で楽曲をいいねする処理を実装しました。

- レコメンド生成画面での「いいね操作」の結果を SoundCloud に即時反映
- 同時に、アプリ内 DB にも「当時の反応ログ（wasLiked）」として記録
- SoundCloud 上での「いいね状態」と DB のログ（wasLiked）は同期しない設計