### PR TITLE
feat(callback): implement callback page with loading UI

### DIFF
--- a/frontend/src/pages/callback.tsx
+++ b/frontend/src/pages/callback.tsx
@@ -55,5 +55,16 @@ export const Callback = () => {
     handleAuthorizationCallback();
   }, []); // SoundCloudからのコールバック時に実行
 
-  return <p>ログイン処理中です...</p>;
+  return (
+    <div className="min-h-screen flex items-center justify-center bg-black text-white px-4">
+      <div className="flex flex-col items-center">
+        {/* ローディングスピナー */}
+        <div className="w-12 h-12 border-[6px] border-white border-t-transparent rounded-full animate-spin" />
+        {/* メッセージ */}
+        <p className="text-sm font-semibold text-gray-300 mt-6">
+          Logging in...
+        </p>
+      </div>
+    </div>
+  );
 };

--- a/frontend/src/pages/login.tsx
+++ b/frontend/src/pages/login.tsx
@@ -10,9 +10,9 @@ export const Login = () => {
   }, []);
 
   const handleLogin = async () => {
-    // ログイン用URL生成
+    // OAuth認証URL生成
     const authorizationUrl = await generateAuthorizationUrl();
-    // ログインページにリダイレクト
+    // OAuth認証画面にリダイレクト
     window.location.href = authorizationUrl;
   };
 


### PR DESCRIPTION
ログイン中の画面にローディングサークルのUIを実装しました。
デモで作成していた `handleAuthorizationCallback` を再利用し、SoundCloudのコールバック処理を実装しました。