### PR TITLE
feat(search): implement artist search UI with follow button

### DIFF
--- a/docs/overall-flow.md
+++ b/docs/overall-flow.md
@@ -43,6 +43,7 @@
     avatarUrl: https:~,
     likedTracksCount: 123,
     permalinkUrl: https:~,
+    isFollowing: true
   },
   ...
 ]
@@ -62,6 +63,7 @@
     avatarUrl: https:~,
     likedTracksCount: 123,
     permalinkUrl: https:~,
+    isFollowing: false
   },
   ...
 ]
@@ -102,26 +104,31 @@
 
 ### GET /api/recommendations/today
 
-- 説明：「今日のレコメンド」を１つ取得する
+- 説明：「今日のレコメンド」を最大３つまで取得する
 - 認証：Cookie(sessionId)
 - レスポンス：
 
 ```json
 {
-  recomendationId: 12345(内部の ID),
-  tracks: [
+  recommendations: [
     {
-      id: 12345(内部の ID),
-      title: FE!N,
-      artworkUrl: https:~,
-      permalinkUrl: https:~, // ウィジェット再生で使用
-      artist: {
-        name: Travis Sccott,
-        avatarUrl: https:~,
-        permalinkUrl: https:~,
-      },
-      wasLiked: true
-    }]
+      recomendationId: 12345(内部の ID),
+      tracks: [
+        {
+          id: 12345(内部の ID),
+          title: FE!N,
+          artworkUrl: https:~,
+          permalinkUrl: https:~, // ウィジェット再生で使用
+          artist: {
+            name: Travis Sccott,
+            avatarUrl: https:~,
+            permalinkUrl: https:~,
+          },
+          wasLiked: true
+        }]
+    },
+    ...
+  ]
 }
 ```
 

--- a/frontend/src/components/HeaderBar.tsx
+++ b/frontend/src/components/HeaderBar.tsx
@@ -1,7 +1,22 @@
-// components/HeaderBar.tsx
 import logo from "../assets/digbeats-logo-transparent.png";
 
-export const HeaderBar = () => {
+type Props = {
+  isSearching: boolean;
+  onSearchFocus: () => void;
+  onSearchCancel: () => void;
+  searchQuery: string;
+  onSearchQueryChange: (q: string) => void;
+  onSearchSubmit: () => void;
+};
+
+export const HeaderBar = ({
+  isSearching,
+  onSearchFocus,
+  onSearchCancel,
+  searchQuery,
+  onSearchQueryChange,
+  onSearchSubmit,
+}: Props) => {
   return (
     // ロゴ ＋ 検索バー ＋ プロフィールアイコン
     <div className="flex items-center justify-between w-full max-w-screen-xl mx-auto px-4 pt-6">
@@ -12,16 +27,32 @@ export const HeaderBar = () => {
         className="w-15 h-15 object-contain"
       />
       {/* 検索バー + プロフィールアイコン */}
-      <div className="flex items-center gap-2 w-[340px]">
+      <div className="flex items-center gap-2 w-full">
+        {/* 検索バー */}
         <input
           type="text"
           placeholder="🔍  Who is your favorite artist?"
+          onFocus={onSearchFocus} // クリックされたら検索モードに入る
+          value={searchQuery}
+          onChange={(e) => onSearchQueryChange(e.target.value)} //　入力の変更されたことを通知し searchQuery を書き換える
+          onKeyDown={(e) => e.key === "Enter" && onSearchSubmit()} // Enter が押されたことを通知し handleSearch を呼び出す
           className="bg-neutral-900 text-white px-4 py-3 rounded-full w-full placeholder-gray-400"
-          disabled
         />
-        <button className="w-10 h-10 bg-neutral-900 rounded-full flex items-center justify-center aspect-square">
-          👤
-        </button>
+        {/* プロフィールアイコン or 検索モード解除ボタン */}
+        {isSearching ? (
+          // 検索モード解除ボタン
+          <button
+            onClick={onSearchCancel}
+            className="text-white text-sm px-3 py-1"
+          >
+            Cancel
+          </button>
+        ) : (
+          // プロフィールアイコン
+          <button className="w-10 h-10 bg-neutral-900 rounded-full flex items-center justify-center aspect-square">
+            👤
+          </button>
+        )}
       </div>
     </div>
   );

--- a/frontend/src/components/SearchResultList.tsx
+++ b/frontend/src/components/SearchResultList.tsx
@@ -1,0 +1,45 @@
+import { Artist } from "../types/artistType";
+
+type Props = {
+  searchResults: Artist[];
+  onFollow: (soundcloudArtistId: number) => void;
+};
+
+export const SearchResultList = ({ searchResults, onFollow }: Props) => {
+  return (
+    // アーティスト検索結果
+    <div className="mt-4 space-y-4 px-4">
+      {searchResults.map((artist) => (
+        <div
+          key={artist.soundcloudArtistId}
+          className="flex items-center justify-between"
+        >
+          {/* アーティストアバター */}
+          <div className="flex items-center gap-3">
+            <img src={artist.avatarUrl} className="w-12 h-12 rounded-full" />
+            {/* アーティスト名・いいね曲数 */}
+            <div>
+              <p className="font-semibold">{artist.name}</p>
+              <p className="text-sm text-gray-400">
+                {artist.likedTracksCount} tracks liked
+              </p>
+            </div>
+          </div>
+          {/* フォローボタン */}
+          <button
+            onClick={() => onFollow(artist.soundcloudArtistId)}
+            className={`px-4 py-2 rounded-full text-sm font-semibold transition 
+              ${
+                artist.isFollowing
+                  ? "bg-orange-400 text-white"
+                  : "border border-white text-white"
+              } 
+            `}
+          >
+            Follow
+          </button>
+        </div>
+      ))}
+    </div>
+  );
+};

--- a/frontend/src/hooks/useSearch.ts
+++ b/frontend/src/hooks/useSearch.ts
@@ -1,0 +1,37 @@
+import { useState } from "react";
+import { Artist } from "../types/artistType";
+import axios from "axios";
+
+export const useSearch = () => {
+  const [searchQuery, setSearchQuery] = useState("");
+  const [searchResults, setSearchResults] = useState<Artist[]>([]);
+
+  const handleSearch = async () => {
+    // 検索クエリが空の場合は検索できない
+    if (!searchQuery.trim()) return;
+    const response = await axios.get(`/api/artists?artistName=${searchQuery}`);
+    setSearchResults(response.data);
+  };
+
+  const handleFollow = async (soundcloudArtistId: number) => {
+    await axios.put(`/api/users/followings/${soundcloudArtistId}`);
+    // フォロー状態を更新(searchResultsを更新)
+    setSearchResults((previous) =>
+      previous.map((artist) =>
+        artist.soundcloudArtistId === soundcloudArtistId
+          ? { ...artist, isFollowing: true } // isFollowingを更新して返す
+          : artist
+      )
+    );
+  };
+
+  return {
+    searchState: { searchQuery, searchResults },
+    actions: {
+      setSearchQuery,
+      setSearchResults,
+      handleSearch,
+      handleFollow,
+    },
+  };
+};

--- a/frontend/src/pages/Home.tsx
+++ b/frontend/src/pages/Home.tsx
@@ -1,9 +1,14 @@
+import { useState } from "react";
 import { useRecommendation } from "../hooks/useRecommendation";
+import { useSearch } from "../hooks/useSearch";
 import { HeaderBar } from "../components/HeaderBar";
 import { RecommendationButtons } from "../components/RecommendationButtons";
 import { RecommendedTrackList } from "../components/RecommendedTrackList";
+import { SearchResultList } from "../components/SearchResultList";
 
 export const Home = () => {
+  const [isSearching, setIsSearching] = useState(false); // 検索モード
+
   const {
     recommendationState: {
       recommendation,
@@ -15,31 +20,59 @@ export const Home = () => {
     actions: { handleGenerate, handleSave, toggleLike, toggleExpand },
   } = useRecommendation();
 
+  const {
+    searchState: { searchQuery, searchResults },
+    actions: { setSearchQuery, setSearchResults, handleSearch, handleFollow },
+  } = useSearch();
+
   // 「まだ今日のレコメンドが無い」 かつ 「生成されたレコメンドがある」　場合に保存できる
   const canSave = !isSaved && recommendation !== null;
 
   return (
     <div className="min-h-screen bg-black text-white">
       {/* ロゴ ＋ 検索バー ＋ プロフィールアイコン */}
-      <HeaderBar />
-
-      {/* レコメンドボタン */}
-      <RecommendationButtons
-        generateCount={generateCount}
-        onGenerate={handleGenerate}
-        onSave={handleSave}
-        canSave={canSave}
+      <HeaderBar
+        // モード切り替え
+        isSearching={isSearching}
+        onSearchFocus={() => setIsSearching(true)}
+        onSearchCancel={() => {
+          setIsSearching(false);
+          setSearchQuery(""); // クエリをクリア
+          setSearchResults([]); // 検索結果もクリア
+        }}
+        // 検索機能
+        searchQuery={searchQuery}
+        onSearchQueryChange={setSearchQuery} // 通知されたら、検索クエリを変更
+        onSearchSubmit={handleSearch} // 通知されたら、検索処理
       />
 
-      {/* 「レコメンド生成結果」 or 「今日のレコメンド」 を表示 */}
-      <RecommendedTrackList
-        tracks={recommendation?.tracks || []} // mapで使うため、track　が　undefined　の場合は　[] を渡す
-        isSaved={isSaved}
-        likedTrackIds={likedTrackIds}
-        expandedTrackId={expandedTrackId}
-        onToggleLike={toggleLike}
-        onToggleExpand={toggleExpand}
-      />
+      {/* アーティスト検索結果 */}
+      {isSearching ? (
+        <SearchResultList
+          searchResults={searchResults}
+          onFollow={handleFollow}
+        />
+      ) : (
+        <>
+          {/* レコメンドボタン */}
+          <RecommendationButtons
+            generateCount={generateCount}
+            onGenerate={handleGenerate}
+            onSave={handleSave}
+            canSave={canSave}
+          />
+
+          {/* 「レコメンド生成結果」 or 「今日のレコメンド」 を表示 */}
+          <RecommendedTrackList
+            tracks={recommendation?.tracks || []} // mapで使うため、track　が　undefined　の場合は　[] を渡す
+            isSaved={isSaved}
+            likedTrackIds={likedTrackIds}
+            expandedTrackId={expandedTrackId}
+            onToggleLike={toggleLike}
+            onToggleExpand={toggleExpand}
+          />
+        </>
+      )}
     </div>
   );
 };

--- a/frontend/src/types/artistType.ts
+++ b/frontend/src/types/artistType.ts
@@ -1,0 +1,8 @@
+export type Artist = {
+  soundcloudArtistId: number;
+  name: string;
+  avatarUrl: string;
+  permalinkUrl: string;
+  likedTracksCount: number;
+  isFollowing: boolean;
+};


### PR DESCRIPTION
検索バーからアーティストを検索し、その場でフォローできるUIを実装しました。

- 検索モードの状態管理（isSearching）を追加し、「通常ホーム画面」と「検索画面」のUIを切り替え
- 検索バーをクリックして入力し、EnterキーでAPI検索を実行
- 検索結果にフォローボタンを表示し、フォロー済みかどうかで表示切り替え（Follow / Following）
- 検索モードではキャンセルボタンを表示し、通常ホーム画面に戻れるように

