### PR TITLE
feat(profile): implement profile page with following artists and recommendation history

### DIFF
--- a/backend/src/application/usecase/getHistorysUseCase.ts
+++ b/backend/src/application/usecase/getHistorysUseCase.ts
@@ -15,9 +15,9 @@ export class GetHistorysUseCase {
     const userId = session.userId;
 
     // レコメンド履歴を取得
-    const historys = await this._historyDbRepository.get(userId, 20);
+    const histories = await this._historyDbRepository.get(userId, 20);
 
     // レコメンド履歴をコントローラーに返す
-    return historys;
+    return histories;
   }
 }

--- a/backend/src/presentation/controller/recommendationController.ts
+++ b/backend/src/presentation/controller/recommendationController.ts
@@ -35,7 +35,7 @@ export class RecommendationController {
     const sessionId = req.cookies.sessionId;
 
     // ユースケース
-    const historys = await this._getHistorysUseCase.run(sessionId);
+    const histories = await this._getHistorysUseCase.run(sessionId);
 
     // レスポンス
     res
@@ -45,7 +45,7 @@ export class RecommendationController {
         sameSite: "none", // TODO：　時間があればCSRF対策　で　csurfを導入する
       })
       .status(200)
-      .json({ historys: historys });
+      .json({ histories: histories });
   }
 
   // レコメンド楽曲にいいねをする

--- a/backend/src/presentation/router/artistRouter.ts
+++ b/backend/src/presentation/router/artistRouter.ts
@@ -5,4 +5,7 @@ import { artistController } from "../di/artistController.di";
 export const artistRouter = Router();
 
 // アーティストを検索するエンドポイント
-artistRouter.get("/api/artists", asyncHandler(artistController.searchArtists));
+artistRouter.get(
+  "/api/artists/search",
+  asyncHandler(artistController.searchArtists)
+);

--- a/backend/src/presentation/router/recommendationRouter.ts
+++ b/backend/src/presentation/router/recommendationRouter.ts
@@ -12,7 +12,7 @@ recommendationRouter.get(
 
 // レコメンド履歴を取得するエンドポイント
 recommendationRouter.get(
-  "/api/recommendations/historys",
+  "/api/recommendations/histories",
   asyncHandler(recommendationController.getHistorys)
 );
 

--- a/docs/overall-flow.md
+++ b/docs/overall-flow.md
@@ -34,6 +34,22 @@
 }
 ```
 
+### GET /api/users
+
+- 説明： 自身のプロフィール情報を SoundCloud で取得する
+- 認証：Cookie(sessionId)
+- レスポンス：
+
+```json
+{
+  "user": {
+    "name": "User1",
+    "avatarUrl": "https:~",
+    "permalinkUrl": "https:~"
+  }
+}
+```
+
 ### GET /api/users/followings
 
 - 説明： フォロ中のアーティストを SoundCloud で取得する
@@ -41,35 +57,39 @@
 - レスポンス：
 
 ```json
-[
-  {
-    "soundcloudArtistId": 12345,
-    "name": "Travis Sccott",
-    "avatarUrl": "https:~",
-    "permalinkUrl": "https:~",
-    "likedTracksCount": 123
-  }
-  // ...
-]
+{
+  "artists": [
+    {
+      "soundcloudArtistId": 12345,
+      "name": "Travis Sccott",
+      "avatarUrl": "https:~",
+      "permalinkUrl": "https:~",
+      "likedTracksCount": 123
+    }
+    // ...
+  ]
+}
 ```
 
-### GET /api/artists/`?artistName=Travis+Scott`
+### GET /api/artists/search`?artistName=Travis+Scott`
 
 - 説明：アーティストを SoundCloud で検索する
 - 認証：Cookie(sessionId)
 - レスポンス：
 
 ```json
-[
-  {
-    "soundcloudArtistId": 12345,
-    "name": "Travis Sccott",
-    "avatarUrl": "https:~",
-    "permalinkUrl": "https:~",
-    "likedTracksCount": 123
-  }
-  // ...
-]
+{
+  "artists": [
+    {
+      "soundcloudArtistId": 12345,
+      "name": "Travis Sccott",
+      "avatarUrl": "https:~",
+      "permalinkUrl": "https:~",
+      "likedTracksCount": 123
+    }
+    // ...
+  ]
+}
 ```
 
 ### POST /api/users/followings
@@ -107,22 +127,24 @@
 
 ```json
 {
-  recomendationId: 12345(内部のID),
-  "recommendedAt": "2025-04-18T10:00:00Z",
-  tracks: [
-    {
-      "id": 12345(内部のID),
-      "title": "FE!N",
-      "artworkUrl": "https:~",
-      "permalinkUrl": "https:~", // ウィジェット再生で使用
-      "artist": {
-        "name": "Travis Sccott",
-        "avatarUrl": "https:~",
-        "permalinkUrl": "https:~",
-      }
-    },
-    // ...
-  ]
+  "recommendation": {
+    "recommendationId": 12345(内部のID),
+    "recommendedAt": "2025-04-18T10:00:00Z",
+    "tracks": [
+      {
+        "id": 12345(内部のID),
+        "title": "FE!N",
+        "artworkUrl": "https:~",
+        "permalinkUrl": "https:~", // ウィジェット再生で使用
+        "artist": {
+          "name": "Travis Sccott",
+          "avatarUrl": "https:~",
+          "permalinkUrl": "https:~",
+        }
+      },
+      // ...
+    ]
+  }
 }
 ```
 
@@ -134,9 +156,9 @@
 
 ```json
 {
-  recommendations: [
+  "recommendations": [
     {
-      "recomendationId": 12345(内部のID),
+      "recommendationId": 12345(内部のID),
       "recommendedAt": "2025-04-18T10:00:00Z",
       "tracks": [
         {
@@ -158,18 +180,19 @@
 }
 ```
 
-### GET /api/recommendations/historys
+### GET /api/recommendations/histories
 
 - 説明：楽曲レコメンド履歴を取得する
 - 認証：Cookie(sessionId)
 - レスポンス：
 
 ```json
-[
-  {
-    "recommendationId": 12345(内部のID),
-    "recommendedAt": "2025-04-18T10:00:00Z",
-    "tracks": [
+{
+  "histories": [
+    {
+      "recommendationId": 12345(内部のID),
+      "recommendedAt": "2025-04-18T10:00:00Z",
+      "tracks": [
         {
           "id": 12345(内部の ID),
           "title": "FE!N",
@@ -183,9 +206,10 @@
         },
         // ...
         ]
-  },
-  // ...
-]
+    },
+    // ...
+  ]
+}
 ```
 
 ### GET /api/users/likes

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -2,6 +2,7 @@ import { Routes, Route } from "react-router-dom";
 import { Login } from "./pages/Login";
 import { Callback } from "./pages/Callback";
 import { Home } from "./pages/Home";
+import { Profile } from "./pages/Profile";
 
 export function App() {
   return (
@@ -10,6 +11,7 @@ export function App() {
         <Route path="/login" element={<Login />} />
         <Route path="/callback" element={<Callback />} />
         <Route path="/" element={<Home />} />
+        <Route path="/profile" element={<Profile />} />
         <Route path="*" element={<h1>Not Found Page</h1>} />
       </Routes>
     </>

--- a/frontend/src/components/HeaderBar.tsx
+++ b/frontend/src/components/HeaderBar.tsx
@@ -1,4 +1,7 @@
+import { useNavigate } from "react-router-dom";
+import { useUser } from "../hooks/useUser";
 import logo from "../assets/digbeats-logo-transparent.png";
+import { Avatar } from "@mui/material";
 
 type Props = {
   isSearching: boolean;
@@ -17,6 +20,9 @@ export const HeaderBar = ({
   onSearchQueryChange,
   onSearchSubmit,
 }: Props) => {
+  const navigate = useNavigate();
+  const { user } = useUser();
+
   return (
     // ロゴ ＋ 検索バー ＋ プロフィールアイコン
     <div className="flex items-center justify-between w-full max-w-screen-xl mx-auto px-4 pt-6">
@@ -49,8 +55,12 @@ export const HeaderBar = ({
           </button>
         ) : (
           // プロフィールアイコン
-          <button className="w-10 h-10 bg-neutral-900 rounded-full flex items-center justify-center aspect-square">
-            👤
+          <button onClick={() => navigate("/profile")}>
+            <Avatar
+              src={user?.avatarUrl} // 画像が設定されてなければ MUI のイニシャルアバター
+              alt={user?.name}
+              sx={{ width: 40, height: 40 }}
+            />
           </button>
         )}
       </div>

--- a/frontend/src/components/HistoryList.tsx
+++ b/frontend/src/components/HistoryList.tsx
@@ -1,0 +1,58 @@
+import { Recommendation } from "../types/recommendationType";
+import { RecommendedTrackList } from "./RecommendedTrackList";
+
+type Props = {
+  recommendations: Recommendation[];
+  expandedRecommendationId: number | null;
+  likedTrackIds: number[];
+  expandedTrackId: number | null;
+  onToggleExpandRecommendation: (recommendationId: number) => void;
+  onToggleLike: (trackId: number, recommendationId: number) => void;
+  onToggleExpandTrack: (trackId: number) => void;
+};
+
+export const HistoryList = ({
+  recommendations,
+  expandedRecommendationId,
+  likedTrackIds,
+  expandedTrackId,
+  onToggleExpandRecommendation,
+  onToggleLike,
+  onToggleExpandTrack,
+}: Props) => {
+  return (
+    // レコメンド履歴を一覧表示
+    <ul className="grid grid-cols-1 gap-4">
+      {recommendations.map((recommendation) => {
+        return (
+          <li
+            key={recommendation.recommendationId}
+            className="bg-neutral-800 rounded-xl px-4 py-3 cursor-pointer hover:bg-neutral-700 transition"
+            onClick={() =>
+              onToggleExpandRecommendation(recommendation.recommendationId)
+            }
+          >
+            {/* レコメンドを生成した日付 */}
+            <p className="text-sm text-gray-400">
+              {new Date(recommendation.recommendedAt).toLocaleDateString()}
+            </p>
+
+            {/* 展開中のレコメンド　（トラック一覧） */}
+            {expandedRecommendationId === recommendation.recommendationId && (
+              <div className="mt-4">
+                <RecommendedTrackList
+                  tracks={recommendation.tracks}
+                  recommendationId={recommendation.recommendationId}
+                  likedTrackIds={likedTrackIds}
+                  expandedTrackId={expandedTrackId}
+                  onToggleLike={onToggleLike}
+                  onToggleExpandTrack={onToggleExpandTrack}
+                />
+              </div>
+            )}
+          </li>
+        );
+      })}
+    </ul>
+  );
+};

--- a/frontend/src/components/RecommendationList.tsx
+++ b/frontend/src/components/RecommendationList.tsx
@@ -7,7 +7,7 @@ type Props = {
   likedTrackIds: number[];
   expandedTrackId: number | null;
   onToggleLike: (trackId: number, recommendationId: number) => void;
-  onToggleExpand: (trackId: number) => void;
+  onToggleExpandTrack: (trackId: number) => void;
 };
 
 export const RecommendationList = ({
@@ -16,7 +16,7 @@ export const RecommendationList = ({
   likedTrackIds,
   expandedTrackId,
   onToggleLike,
-  onToggleExpand,
+  onToggleExpandTrack,
 }: Props) => {
   return (
     // レコメンド一覧を表示
@@ -41,7 +41,7 @@ export const RecommendationList = ({
               likedTrackIds={likedTrackIds}
               expandedTrackId={expandedTrackId}
               onToggleLike={onToggleLike}
-              onToggleExpand={onToggleExpand}
+              onToggleExpandTrack={onToggleExpandTrack}
             />
           </div>
         );

--- a/frontend/src/components/RecommendedTrackItem.tsx
+++ b/frontend/src/components/RecommendedTrackItem.tsx
@@ -9,7 +9,7 @@ type Props = {
   isLiked: boolean;
   isExpanded: boolean;
   onToggleLike: (trackId: number, recommendationId: number) => void;
-  onToggleExpand: (trackId: number) => void;
+  onToggleExpandTrack: (trackId: number) => void;
 };
 
 export const RecommendedTrackItem = ({
@@ -18,7 +18,7 @@ export const RecommendedTrackItem = ({
   isLiked, // いいねされているか
   isExpanded, // 展開されているか
   onToggleLike,
-  onToggleExpand,
+  onToggleExpandTrack,
 }: Props) => {
   // レコメンドされたトラックを表示
   return (
@@ -30,7 +30,10 @@ export const RecommendedTrackItem = ({
       {/* トラック　（クリックで展開） */}
       <div
         className="flex items-center gap-4 cursor-pointer"
-        onClick={() => onToggleExpand(track.id)}
+        onClick={(e) => {
+          e.stopPropagation(); // 親のonClickの発火を防ぐ
+          onToggleExpandTrack(track.id);
+        }}
       >
         {/* アートワーク */}
         <img

--- a/frontend/src/components/RecommendedTrackList.tsx
+++ b/frontend/src/components/RecommendedTrackList.tsx
@@ -7,7 +7,7 @@ type Props = {
   likedTrackIds: number[];
   expandedTrackId: number | null;
   onToggleLike: (trackId: number, recommendationId: number) => void;
-  onToggleExpand: (trackId: number) => void;
+  onToggleExpandTrack: (trackId: number) => void;
 };
 
 export const RecommendedTrackList = ({
@@ -16,7 +16,7 @@ export const RecommendedTrackList = ({
   likedTrackIds,
   expandedTrackId,
   onToggleLike,
-  onToggleExpand,
+  onToggleExpandTrack,
 }: Props) => {
   return (
     // レコメンドを表示
@@ -29,7 +29,7 @@ export const RecommendedTrackList = ({
           isLiked={likedTrackIds.includes(track.id)} // いいねされているか
           isExpanded={expandedTrackId === track.id} // 展開されているか
           onToggleLike={onToggleLike}
-          onToggleExpand={onToggleExpand}
+          onToggleExpandTrack={onToggleExpandTrack}
         />
       ))}
     </ul>

--- a/frontend/src/components/artistList.tsx
+++ b/frontend/src/components/artistList.tsx
@@ -2,51 +2,56 @@ import { Artist } from "../types/artistType";
 
 type Props = {
   artists: Artist[];
-  followedSoundCloudArtistIds: number[];
-  onToggleFollow: (soundcloudArtistId: number) => void;
+  followedArtists: Artist[];
+  onToggleFollow: (artist: Artist) => void;
 };
 
 export const ArtistList = ({
   artists,
-  followedSoundCloudArtistIds,
+  followedArtists,
   onToggleFollow,
 }: Props) => {
   return (
     // アーティスト検索結果
     <div className="mt-4 space-y-4 px-4">
-      {artists.map((artist) => (
-        <div
-          key={artist.soundcloudArtistId}
-          className="flex items-center justify-between"
-        >
-          {/* アーティストアバター */}
-          <div className="flex items-center gap-3">
-            <img src={artist.avatarUrl} className="w-12 h-12 rounded-full" />
-            {/* アーティスト名・いいね曲数 */}
-            <div>
-              <p className="font-semibold">{artist.name}</p>
-              <p className="text-sm text-gray-400">
-                {artist.likedTracksCount} tracks liked
-              </p>
+      {artists.map((artist) => {
+        // フォロー中かどうか
+        const isFollowed = followedArtists.some(
+          (a) => a.soundcloudArtistId === artist.soundcloudArtistId
+        );
+
+        return (
+          <div
+            key={artist.soundcloudArtistId}
+            className="flex items-center justify-between"
+          >
+            {/* アーティストアバター */}
+            <div className="flex items-center gap-3">
+              <img src={artist.avatarUrl} className="w-12 h-12 rounded-full" />
+              {/* アーティスト名・いいね曲数 */}
+              <div>
+                <p className="font-semibold">{artist.name}</p>
+                <p className="text-sm text-gray-400">
+                  {artist.likedTracksCount} tracks liked
+                </p>
+              </div>
             </div>
-          </div>
-          {/* フォローボタン */}
-          <button
-            onClick={() => onToggleFollow(artist.soundcloudArtistId)}
-            className={`px-4 py-2 rounded-full text-sm font-semibold transition 
+            {/* フォローボタン */}
+            <button
+              onClick={() => onToggleFollow(artist)}
+              className={`px-4 py-2 rounded-full text-sm font-semibold transition 
               ${
-                followedSoundCloudArtistIds.includes(artist.soundcloudArtistId)
+                isFollowed
                   ? "bg-orange-400 text-white" // フォロー済み
                   : "border border-white text-white" // 未フォロー
               } 
             `}
-          >
-            {followedSoundCloudArtistIds.includes(artist.soundcloudArtistId)
-              ? "Following"
-              : "Follow"}
-          </button>
-        </div>
-      ))}
+            >
+              {isFollowed ? "Following" : "Follow"}
+            </button>
+          </div>
+        );
+      })}
     </div>
   );
 };

--- a/frontend/src/hooks/useHistory.ts
+++ b/frontend/src/hooks/useHistory.ts
@@ -1,0 +1,38 @@
+import { useEffect, useState } from "react";
+import { Recommendation } from "../types/recommendationType";
+import axios from "axios";
+
+export const useHistory = () => {
+  const [histories, setHistories] = useState<Recommendation[]>([]);
+  const [expandedRecommendationId, setExpandedRecommendationId] = useState<
+    number | null
+  >(null);
+
+  useEffect(() => {
+    // レコメンド履歴を取得
+    const fetchHistories = async () => {
+      try {
+        const response = await axios.get("/api/recommendations/histories", {
+          withCredentials: true,
+        });
+        setHistories(response.data);
+      } catch (error) {
+        console.error("Failed to fetch recommendation histories", error);
+      }
+    };
+
+    fetchHistories();
+  }, []);
+
+  // レコメンドの展開状態を切り替え
+  const toggleExpandRecommendation = (recommendationId: number) => {
+    setExpandedRecommendationId(
+      (previous: number | null) =>
+        previous === recommendationId
+          ? null // すでに展開されていたら閉じる
+          : recommendationId // 別のレコメンドを展開ししていたら、上書きで切り替える
+    );
+  };
+
+  return { histories, expandedRecommendationId, toggleExpandRecommendation };
+};

--- a/frontend/src/hooks/useRecommendation.ts
+++ b/frontend/src/hooks/useRecommendation.ts
@@ -7,8 +7,8 @@ export const useRecommendation = () => {
   const [todaysGenerateCount, setTodaysGenerateCount] = useState(0);
   const [animatedId, setAnimatedId] = useState<number | null>(null);
 
-  // 「今日のレコメンド」 を取得
   useEffect(() => {
+    // 「今日のレコメンド」 を取得
     const fetchTodayRecommendation = async () => {
       try {
         const response = await axios.get("/api/recommendations/today", {

--- a/frontend/src/hooks/useSearch.ts
+++ b/frontend/src/hooks/useSearch.ts
@@ -12,7 +12,7 @@ export const useSearch = () => {
 
     try {
       const response = await axios.get(
-        `/api/artists?artistName=${searchQuery}`
+        `/api/artists/search?artistName=${searchQuery}`
       );
       setArtists(response.data);
     } catch (error) {

--- a/frontend/src/hooks/useTrack.ts
+++ b/frontend/src/hooks/useTrack.ts
@@ -4,7 +4,7 @@ export const useTrack = () => {
   const [expandedTrackId, setExpandedTrackId] = useState<number | null>(null); // 展開するのは１つだけ
 
   // 展開するトラックを切り替え
-  const toggleExpand = (trackId: number) => {
+  const toggleExpandTrack = (trackId: number) => {
     setExpandedTrackId(
       (previous: number | null) =>
         previous === trackId
@@ -15,6 +15,6 @@ export const useTrack = () => {
 
   return {
     expandedTrackId,
-    toggleExpand,
+    toggleExpandTrack,
   };
 };

--- a/frontend/src/hooks/useUser.ts
+++ b/frontend/src/hooks/useUser.ts
@@ -1,0 +1,24 @@
+import { useState, useEffect } from "react";
+import { User } from "../types/userType";
+import axios from "axios";
+
+export const useUser = () => {
+  const [user, setUser] = useState<User>();
+
+  useEffect(() => {
+    const fetchUser = async () => {
+      try {
+        const response = await axios.get("/api/users", {
+          withCredentials: true,
+        });
+        setUser(response.data);
+      } catch (error) {
+        console.error("Failed to fetch user", error);
+      }
+    };
+
+    fetchUser();
+  }, []);
+
+  return { user };
+};

--- a/frontend/src/pages/Home.tsx
+++ b/frontend/src/pages/Home.tsx
@@ -6,7 +6,7 @@ import { useLike } from "../hooks/useLike";
 import { useTrack } from "../hooks/useTrack";
 import { HeaderBar } from "../components/HeaderBar";
 import { RecommendationButtons } from "../components/RecommendationButtons";
-import { ArtistList } from "../components/artistList";
+import { ArtistList } from "../components/ArtistList";
 import { RecommendationList } from "../components/RecommendationList";
 
 export const Home = () => {
@@ -15,12 +15,12 @@ export const Home = () => {
   // アーティスト検索画面のHooks
   const { artists, searchQuery, setArtists, setSearchQuery, handleSearch } =
     useSearch();
-  const { followedSoundCloudArtistIds, toggleFollow } = useFollow();
+  const { followedArtists, toggleFollow } = useFollow();
   // レコメンド画面のHooks
   const { recommendations, todaysGenerateCount, animatedId, handleGenerate } =
     useRecommendation();
   const { likedTrackIds, toggleLike } = useLike();
-  const { expandedTrackId, toggleExpand } = useTrack();
+  const { expandedTrackId, toggleExpandTrack } = useTrack();
 
   return (
     <div className="min-h-screen bg-black text-white">
@@ -43,7 +43,7 @@ export const Home = () => {
         // アーティスト検索画面
         <ArtistList
           artists={artists}
-          followedSoundCloudArtistIds={followedSoundCloudArtistIds}
+          followedArtists={followedArtists}
           onToggleFollow={toggleFollow}
         />
       ) : (
@@ -74,7 +74,7 @@ export const Home = () => {
               likedTrackIds={likedTrackIds}
               expandedTrackId={expandedTrackId}
               onToggleLike={toggleLike}
-              onToggleExpand={toggleExpand}
+              onToggleExpandTrack={toggleExpandTrack}
             />
           )}
         </>

--- a/frontend/src/pages/Profile.tsx
+++ b/frontend/src/pages/Profile.tsx
@@ -1,0 +1,91 @@
+import { useState } from "react";
+import { useUser } from "../hooks/useUser";
+import { useHistory } from "../hooks/useHistory";
+import { useFollow } from "../hooks/useFollow";
+import { useLike } from "../hooks/useLike";
+import { useTrack } from "../hooks/useTrack";
+import { HistoryList } from "../components/HistoryList";
+import { Avatar } from "@mui/material";
+import { ArtistList } from "../components/ArtistList";
+
+export const Profile = () => {
+  // 画面切り替え用のHooks
+  const [isViewingFollowings, setIsViewingFollowings] = useState(false);
+  // プロフィール画面のHooks
+  const { user } = useUser();
+  // フォロー中アーティスト一覧画面のHooks
+  const { followedArtists, toggleFollow } = useFollow();
+  // レコメンド履歴のHooks
+  const { histories, expandedRecommendationId, toggleExpandRecommendation } =
+    useHistory();
+  const { likedTrackIds, toggleLike } = useLike();
+  const { expandedTrackId, toggleExpandTrack } = useTrack();
+
+  return (
+    <div className="min-h-screen bg-black text-white px-6 py-4 space-y-6">
+      {/* 状態変数によってプロフィール画面を切り替え */}
+      {isViewingFollowings ? (
+        // フォロー中アーティスト一覧画面
+        <>
+          {/* フォロー中アーティスト一覧 */}
+          <div className="flex items-center justify-between">
+            <p className="text-lg font-bold">Following Artists</p>
+            <button
+              className="text-sm text-gray-400"
+              onClick={() => setIsViewingFollowings(false)}
+            >
+              Back
+            </button>
+          </div>
+          <ArtistList
+            artists={followedArtists}
+            followedArtists={followedArtists}
+            onToggleFollow={toggleFollow}
+          />
+        </>
+      ) : (
+        <>
+          {/* プロフィールセクション */}
+          <div className="flex flex-col items-center gap-2">
+            <Avatar
+              src={user?.avatarUrl}
+              alt={user?.name}
+              sx={{ width: 96, height: 96 }}
+            />
+            <p className="text-xl font-bold">{user?.name ?? "Unknown User"}</p>
+
+            <div className="flex gap-8 mt-2 text-center">
+              <div>
+                <p className="text-lg font-semibold">{histories.length}</p>
+                <p className="text-xs text-gray-400">レコメンド</p>
+              </div>
+              <div
+                className="cursor-pointer hover:underline"
+                onClick={() => setIsViewingFollowings(true)}
+              >
+                <p className="text-lg font-semibold">
+                  {followedArtists.length}
+                </p>
+                <p className="text-xs text-gray-400">フォロー中</p>
+              </div>
+            </div>
+          </div>
+
+          {/* レコメンド履歴 */}
+          <div className="space-y-2">
+            <p className="text-base font-semibold">レコメンド履歴</p>
+            <HistoryList
+              recommendations={histories}
+              expandedRecommendationId={expandedRecommendationId}
+              likedTrackIds={likedTrackIds}
+              expandedTrackId={expandedTrackId}
+              onToggleExpandRecommendation={toggleExpandRecommendation}
+              onToggleLike={toggleLike}
+              onToggleExpandTrack={toggleExpandTrack}
+            />
+          </div>
+        </>
+      )}
+    </div>
+  );
+};

--- a/frontend/src/types/userType.ts
+++ b/frontend/src/types/userType.ts
@@ -1,0 +1,5 @@
+export type User = {
+  name: string;
+  avatarUrl: string;
+  permalinkUrl: string;
+};


### PR DESCRIPTION
プロフィール画面を追加し、ユーザー情報・フォロー中アーティスト・レコメンド履歴を一画面で確認できるようにしました。

- useUser を使って SoundCloud のユーザープロフィール（アバター・名前）を表示
- フォロー中アーティスト数を表示し、タップで一覧ページに遷移（useFollow 利用）
- 一覧ページでは ArtistList を再利用し、フォロー／解除ボタンを即時反映
- ユーザーが過去に生成したレコメンド履歴を useHistory で取得し、日付ごとに展開表示
- 展開後は RecommendedTrackList を使って各楽曲を表示、useLike / useTrack でいいね・展開操作に対応